### PR TITLE
Add dynamic breadcrumb

### DIFF
--- a/app/(protected)/dashboard/layout.tsx
+++ b/app/(protected)/dashboard/layout.tsx
@@ -1,12 +1,5 @@
 import { AppSidebar } from "@/components/app-sidebar"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb"
+import { DynamicBreadcrumb } from "@/components/dynamic-breadcrumb"
 import { Separator } from "@/components/ui/separator"
 import {
   SidebarInset,
@@ -30,19 +23,7 @@ export default function DashboardLayout({
               orientation="vertical"
               className="mr-2 data-[orientation=vertical]:h-4"
             />
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem className="hidden md:block">
-                  <BreadcrumbLink href="#">
-                    Building Your Application
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator className="hidden md:block" />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>Data Fetching</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
+            <DynamicBreadcrumb />
           </div>
         </header>
         <div className="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/components/dynamic-breadcrumb.tsx
+++ b/components/dynamic-breadcrumb.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import React from 'react'
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb'
+
+const LABELS: Record<string, string> = {
+  dashboard: 'Dashboard',
+  associacoes: 'Associações',
+  tarefas: 'Tarefas',
+  usuarios: 'Usuários',
+}
+
+export function DynamicBreadcrumb() {
+  const pathname = usePathname()
+  const segments = React.useMemo(
+    () => pathname.split('/').filter(Boolean),
+    [pathname]
+  )
+
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        {segments.map((segment, index) => {
+          const href = '/' + segments.slice(0, index + 1).join('/')
+          const label = LABELS[segment] ?? decodeURIComponent(segment)
+          const isLast = index === segments.length - 1
+          return (
+            <React.Fragment key={href}>
+              <BreadcrumbItem>
+                {isLast ? (
+                  <BreadcrumbPage>{label}</BreadcrumbPage>
+                ) : (
+                  <BreadcrumbLink href={href}>{label}</BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+              {!isLast && <BreadcrumbSeparator className="hidden md:block" />}
+            </React.Fragment>
+          )
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  )
+}


### PR DESCRIPTION
## Summary
- add DynamicBreadcrumb component that uses the current pathname
- show breadcrumb in the dashboard layout

## Testing
- `npx next lint` *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6886aa185df4832bb79ff4ede81fdb65