### PR TITLE
Fix prisma import in criarTarefa repository

### DIFF
--- a/src/backend/prisma/client.ts
+++ b/src/backend/prisma/client.ts
@@ -1,0 +1,1 @@
+export { prisma } from '../../../prisma/client'

--- a/src/backend/repositories/tarefas/criarTarefa.repository.ts
+++ b/src/backend/repositories/tarefas/criarTarefa.repository.ts
@@ -1,5 +1,6 @@
 
 import { TarefaInput } from '@backend/shared/validators/tarefa'
+import { prisma } from '@backend/prisma/client'
 
 export function criarTarefa(data: TarefaInput) {
   return prisma.tarefa.create({ data })


### PR DESCRIPTION
## Summary
- add missing prisma import to `criarTarefa.repository`
- expose prisma under `src/backend/prisma` for path alias compatibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889590fe600832b8bc947d14a7c0094