### PR TITLE
Add tests for task search with filters and pagination

### DIFF
--- a/src/app/api/tarefas/buscar/route.ts
+++ b/src/app/api/tarefas/buscar/route.ts
@@ -1,0 +1,11 @@
+import { buscarTarefasUsecase } from '@backend/usecases/tarefas/buscarTarefas.usecase'
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const params = Object.fromEntries(url.searchParams.entries())
+  const result = await buscarTarefasUsecase(params as any)
+  return new Response(JSON.stringify(result), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}

--- a/src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@backend/prisma/client', () => ({
+  prisma: {
+    tarefa: {
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0)
+    }
+  }
+}))
+
+import { prisma } from '@backend/prisma/client'
+import { buscarTarefas } from '../buscarTarefas.repository'
+
+describe('buscarTarefas.repository', () => {
+  it('chama prisma com filtros e paginacao', async () => {
+    await buscarTarefas({ page: 2, perPage: 5, statusId: '1', titulo: 'test', prioridade: 'alta' } as any)
+    expect(prisma.tarefa.findMany).toHaveBeenCalledWith({
+      where: { statusId: '1', prioridade: 'alta', titulo: { contains: 'test', mode: 'insensitive' } },
+      skip: 5,
+      take: 5
+    })
+    expect(prisma.tarefa.count).toHaveBeenCalledWith({
+      where: { statusId: '1', prioridade: 'alta', titulo: { contains: 'test', mode: 'insensitive' } }
+    })
+  })
+})

--- a/src/backend/repositories/tarefas/buscarTarefas.repository.ts
+++ b/src/backend/repositories/tarefas/buscarTarefas.repository.ts
@@ -1,0 +1,22 @@
+import { prisma } from '@backend/prisma/client'
+import { BuscarTarefasInput } from '@backend/shared/validators/buscarTarefas'
+
+export async function buscarTarefas({ page, perPage, titulo, statusId, prioridade }: BuscarTarefasInput) {
+  const where: any = {}
+  if (titulo) {
+    where.titulo = { contains: titulo, mode: 'insensitive' }
+  }
+  if (statusId) {
+    where.statusId = statusId
+  }
+  if (prioridade) {
+    where.prioridade = prioridade
+  }
+
+  const [tarefas, total] = await Promise.all([
+    prisma.tarefa.findMany({ where, skip: (page - 1) * perPage, take: perPage }),
+    prisma.tarefa.count({ where })
+  ])
+
+  return { tarefas, total }
+}

--- a/src/backend/shared/validators/buscarTarefas.ts
+++ b/src/backend/shared/validators/buscarTarefas.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const buscarTarefasSchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  perPage: z.coerce.number().int().positive().max(100).default(10),
+  titulo: z.string().optional(),
+  statusId: z.string().uuid().optional(),
+  prioridade: z.string().optional()
+})
+
+export type BuscarTarefasInput = z.infer<typeof buscarTarefasSchema>

--- a/src/backend/tests/buscarTarefas.e2e.spec.ts
+++ b/src/backend/tests/buscarTarefas.e2e.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../../app/api/tarefas/buscar/route'
+
+vi.mock('@backend/usecases/tarefas/buscarTarefas.usecase', () => {
+  return {
+    buscarTarefasUsecase: vi.fn().mockResolvedValue({ tarefas: [], total: 0 })
+  }
+})
+
+import { buscarTarefasUsecase } from '@backend/usecases/tarefas/buscarTarefas.usecase'
+
+describe('GET /api/tarefas/buscar', () => {
+  it('retorna 200 e chama usecase', async () => {
+    const url = new URL('http://localhost/api/tarefas/buscar?statusId=1&page=1&perPage=10')
+    const req = new Request(url.toString())
+    const res = await GET(req as any)
+    expect(res.status).toBe(200)
+    expect(buscarTarefasUsecase).toHaveBeenCalledWith({
+      statusId: '1',
+      page: '1',
+      perPage: '10'
+    })
+  })
+})

--- a/src/backend/usecases/tarefas/__tests__/buscarTarefas.usecase.spec.ts
+++ b/src/backend/usecases/tarefas/__tests__/buscarTarefas.usecase.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@backend/repositories/tarefas/buscarTarefas.repository', () => ({
+  buscarTarefas: vi.fn()
+}))
+
+import { buscarTarefas } from '@backend/repositories/tarefas/buscarTarefas.repository'
+import { buscarTarefasUsecase } from '../buscarTarefas.usecase'
+
+describe('buscarTarefasUsecase', () => {
+  it('valida dados e chama repositorio', async () => {
+    const spy = vi.mocked(buscarTarefas)
+    spy.mockResolvedValue({ tarefas: [], total: 0 })
+    await buscarTarefasUsecase({
+      page: '2',
+      perPage: '5',
+      statusId: '00000000-0000-0000-0000-000000000000',
+      titulo: 'abc'
+    } as any)
+    expect(spy).toHaveBeenCalledWith({
+      page: 2,
+      perPage: 5,
+      statusId: '00000000-0000-0000-0000-000000000000',
+      titulo: 'abc'
+    })
+  })
+})

--- a/src/backend/usecases/tarefas/buscarTarefas.usecase.ts
+++ b/src/backend/usecases/tarefas/buscarTarefas.usecase.ts
@@ -1,0 +1,7 @@
+import { buscarTarefas } from '@backend/repositories/tarefas/buscarTarefas.repository'
+import { BuscarTarefasInput, buscarTarefasSchema } from '@backend/shared/validators/buscarTarefas'
+
+export async function buscarTarefasUsecase(input: BuscarTarefasInput) {
+  const data = buscarTarefasSchema.parse(input)
+  return buscarTarefas(data)
+}


### PR DESCRIPTION
## Summary
- implement GET route to search tasks with pagination and filtering
- add validator, repository, and use case for task search
- create unit and end-to-end tests for searching tasks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68956fd9f8dc832b82e8cd1bf48b95e4