### PR TITLE
feat: add association search endpoint

### DIFF
--- a/src/app/api/associacoes/README.md
+++ b/src/app/api/associacoes/README.md
@@ -1,0 +1,1 @@
+Endpoints for association (associacao) management.

--- a/src/app/api/associacoes/buscar/route.ts
+++ b/src/app/api/associacoes/buscar/route.ts
@@ -1,0 +1,11 @@
+import { buscarAssociacoesUsecase } from '@backend/usecases/associacoes/buscarAssociacoes.usecase'
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const params = Object.fromEntries(url.searchParams.entries())
+  const result = await buscarAssociacoesUsecase(params as any)
+  return new Response(JSON.stringify(result), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}

--- a/src/backend/repositories/associacoes/__tests__/buscarAssociacoes.repository.spec.ts
+++ b/src/backend/repositories/associacoes/__tests__/buscarAssociacoes.repository.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@backend/prisma/client', () => ({
+  prisma: {
+    associacao: {
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0)
+    }
+  }
+}))
+
+import { prisma } from '@backend/prisma/client'
+import { buscarAssociacoes } from '../buscarAssociacoes.repository'
+
+describe('buscarAssociacoes.repository', () => {
+  it('chama prisma com filtros e paginacao', async () => {
+    await buscarAssociacoes({ page: 2, perPage: 5, nome: 'test', cidade: 'city', estado: 'SP' } as any)
+    expect(prisma.associacao.findMany).toHaveBeenCalledWith({
+      where: {
+        nome: { contains: 'test', mode: 'insensitive' },
+        cidade: { contains: 'city', mode: 'insensitive' },
+        estado: 'SP'
+      },
+      skip: 5,
+      take: 5
+    })
+    expect(prisma.associacao.count).toHaveBeenCalledWith({
+      where: {
+        nome: { contains: 'test', mode: 'insensitive' },
+        cidade: { contains: 'city', mode: 'insensitive' },
+        estado: 'SP'
+      }
+    })
+  })
+})

--- a/src/backend/repositories/associacoes/buscarAssociacoes.repository.ts
+++ b/src/backend/repositories/associacoes/buscarAssociacoes.repository.ts
@@ -1,0 +1,22 @@
+import { prisma } from '@backend/prisma/client'
+import { BuscarAssociacoesInput } from '@backend/shared/validators/buscarAssociacoes'
+
+export async function buscarAssociacoes({ page, perPage, nome, cidade, estado }: BuscarAssociacoesInput) {
+  const where: any = {}
+  if (nome) {
+    where.nome = { contains: nome, mode: 'insensitive' }
+  }
+  if (cidade) {
+    where.cidade = { contains: cidade, mode: 'insensitive' }
+  }
+  if (estado) {
+    where.estado = estado
+  }
+
+  const [associacoes, total] = await Promise.all([
+    prisma.associacao.findMany({ where, skip: (page - 1) * perPage, take: perPage }),
+    prisma.associacao.count({ where })
+  ])
+
+  return { associacoes, total }
+}

--- a/src/backend/shared/validators/buscarAssociacoes.ts
+++ b/src/backend/shared/validators/buscarAssociacoes.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export const buscarAssociacoesSchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  perPage: z.coerce.number().int().positive().max(100).default(10),
+  nome: z.string().optional(),
+  cidade: z.string().optional(),
+  estado: z.string().optional()
+})
+
+export type BuscarAssociacoesInput = z.infer<typeof buscarAssociacoesSchema>

--- a/src/backend/usecases/associacoes/__tests__/buscarAssociacoes.usecase.spec.ts
+++ b/src/backend/usecases/associacoes/__tests__/buscarAssociacoes.usecase.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@backend/repositories/associacoes/buscarAssociacoes.repository', () => ({
+  buscarAssociacoes: vi.fn(),
+}))
+
+import { buscarAssociacoes } from '@backend/repositories/associacoes/buscarAssociacoes.repository'
+import { buscarAssociacoesUsecase } from '../buscarAssociacoes.usecase'
+
+describe('buscarAssociacoesUsecase', () => {
+  it('valida dados e chama repositorio', async () => {
+    const spy = vi.mocked(buscarAssociacoes)
+    spy.mockResolvedValue({ associacoes: [], total: 0 })
+    await buscarAssociacoesUsecase({
+      page: '2',
+      perPage: '5',
+      nome: 'abc',
+      cidade: 'xyz',
+      estado: 'SP'
+    } as any)
+    expect(spy).toHaveBeenCalledWith({
+      page: 2,
+      perPage: 5,
+      nome: 'abc',
+      cidade: 'xyz',
+      estado: 'SP'
+    })
+  })
+})

--- a/src/backend/usecases/associacoes/buscarAssociacoes.usecase.ts
+++ b/src/backend/usecases/associacoes/buscarAssociacoes.usecase.ts
@@ -1,0 +1,7 @@
+import { buscarAssociacoes } from '@backend/repositories/associacoes/buscarAssociacoes.repository'
+import { BuscarAssociacoesInput, buscarAssociacoesSchema } from '@backend/shared/validators/buscarAssociacoes'
+
+export async function buscarAssociacoesUsecase(input: BuscarAssociacoesInput) {
+  const data = buscarAssociacoesSchema.parse(input)
+  return buscarAssociacoes(data)
+}


### PR DESCRIPTION
## Summary
- add association search validator
- implement use case, repository, and API route for association search
- cover association search with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a38750e8e8832baf3b4a101b69f98d