### PR TITLE
feat: add buscar tipos endpoint

### DIFF
--- a/src/app/api/tipos/README.md
+++ b/src/app/api/tipos/README.md
@@ -1,0 +1,1 @@
+Endpoints for type (tipo) management.

--- a/src/app/api/tipos/buscar/route.ts
+++ b/src/app/api/tipos/buscar/route.ts
@@ -1,0 +1,11 @@
+import { buscarTiposUsecase } from '@backend/usecases/tipos/buscarTipos.usecase'
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const params = Object.fromEntries(url.searchParams.entries())
+  const result = await buscarTiposUsecase(params as any)
+  return new Response(JSON.stringify(result), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}

--- a/src/backend/repositories/tipos/__tests__/buscarTipos.repository.spec.ts
+++ b/src/backend/repositories/tipos/__tests__/buscarTipos.repository.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@backend/prisma/client', () => ({
+  prisma: {
+    tipo: {
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0)
+    }
+  }
+}))
+
+import { prisma } from '@backend/prisma/client'
+import { buscarTipos } from '../buscarTipos.repository'
+
+describe('buscarTipos.repository', () => {
+  it('chama prisma com filtros e paginacao', async () => {
+    await buscarTipos({ page: 2, perPage: 5, nome: 'test' } as any)
+    expect(prisma.tipo.findMany).toHaveBeenCalledWith({
+      where: { nome: { contains: 'test', mode: 'insensitive' } },
+      skip: 5,
+      take: 5
+    })
+    expect(prisma.tipo.count).toHaveBeenCalledWith({
+      where: { nome: { contains: 'test', mode: 'insensitive' } }
+    })
+  })
+})

--- a/src/backend/repositories/tipos/buscarTipos.repository.ts
+++ b/src/backend/repositories/tipos/buscarTipos.repository.ts
@@ -1,0 +1,16 @@
+import { prisma } from '@backend/prisma/client'
+import { BuscarTiposInput } from '@backend/shared/validators/buscarTipos'
+
+export async function buscarTipos({ page, perPage, nome }: BuscarTiposInput) {
+  const where: any = {}
+  if (nome) {
+    where.nome = { contains: nome, mode: 'insensitive' }
+  }
+
+  const [tipos, total] = await Promise.all([
+    prisma.tipo.findMany({ where, skip: (page - 1) * perPage, take: perPage }),
+    prisma.tipo.count({ where })
+  ])
+
+  return { tipos, total }
+}

--- a/src/backend/shared/validators/buscarTipos.ts
+++ b/src/backend/shared/validators/buscarTipos.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const buscarTiposSchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  perPage: z.coerce.number().int().positive().max(100).default(10),
+  nome: z.string().optional()
+})
+
+export type BuscarTiposInput = z.infer<typeof buscarTiposSchema>

--- a/src/backend/tests/buscarTipos.e2e.spec.ts
+++ b/src/backend/tests/buscarTipos.e2e.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../../app/api/tipos/buscar/route'
+
+vi.mock('@backend/usecases/tipos/buscarTipos.usecase', () => {
+  return {
+    buscarTiposUsecase: vi.fn().mockResolvedValue({ tipos: [], total: 0 })
+  }
+})
+
+import { buscarTiposUsecase } from '@backend/usecases/tipos/buscarTipos.usecase'
+
+describe('GET /api/tipos/buscar', () => {
+  it('retorna 200 e chama usecase', async () => {
+    const url = new URL('http://localhost/api/tipos/buscar?nome=abc&page=1&perPage=10')
+    const req = new Request(url.toString())
+    const res = await GET(req as any)
+    expect(res.status).toBe(200)
+    expect(buscarTiposUsecase).toHaveBeenCalledWith({
+      nome: 'abc',
+      page: '1',
+      perPage: '10'
+    })
+  })
+})

--- a/src/backend/usecases/tipos/__tests__/buscarTipos.usecase.spec.ts
+++ b/src/backend/usecases/tipos/__tests__/buscarTipos.usecase.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@backend/repositories/tipos/buscarTipos.repository', () => ({
+  buscarTipos: vi.fn()
+}))
+
+import { buscarTipos } from '@backend/repositories/tipos/buscarTipos.repository'
+import { buscarTiposUsecase } from '../buscarTipos.usecase'
+
+describe('buscarTiposUsecase', () => {
+  it('valida dados e chama repositorio', async () => {
+    const spy = vi.mocked(buscarTipos)
+    spy.mockResolvedValue({ tipos: [], total: 0 })
+    await buscarTiposUsecase({ page: '2', perPage: '5', nome: 'abc' } as any)
+    expect(spy).toHaveBeenCalledWith({ page: 2, perPage: 5, nome: 'abc' })
+  })
+})

--- a/src/backend/usecases/tipos/buscarTipos.usecase.ts
+++ b/src/backend/usecases/tipos/buscarTipos.usecase.ts
@@ -1,0 +1,7 @@
+import { buscarTipos } from '@backend/repositories/tipos/buscarTipos.repository'
+import { BuscarTiposInput, buscarTiposSchema } from '@backend/shared/validators/buscarTipos'
+
+export async function buscarTiposUsecase(input: BuscarTiposInput) {
+  const data = buscarTiposSchema.parse(input)
+  return buscarTipos(data)
+}


### PR DESCRIPTION
## Summary
- add validator, repository, and use case for querying tipos
- expose GET /api/tipos/buscar endpoint
- test repository, use case and route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3875d1654832bafba4e552de84e30