### PR TITLE
feat: add collaborators search

### DIFF
--- a/src/app/api/colaboradores/buscar/route.ts
+++ b/src/app/api/colaboradores/buscar/route.ts
@@ -1,0 +1,11 @@
+import { buscarColaboradoresUsecase } from '@backend/usecases/colaboradores/buscarColaboradores.usecase'
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const params = Object.fromEntries(url.searchParams.entries())
+  const result = await buscarColaboradoresUsecase(params as any)
+  return new Response(JSON.stringify(result), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}

--- a/src/backend/repositories/colaboradores/__tests__/buscarColaboradores.repository.spec.ts
+++ b/src/backend/repositories/colaboradores/__tests__/buscarColaboradores.repository.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@backend/prisma/client', () => ({
+  prisma: {
+    usuario: {
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0)
+    }
+  }
+}))
+
+import { prisma } from '@backend/prisma/client'
+import { buscarColaboradores } from '../buscarColaboradores.repository'
+
+describe('buscarColaboradores.repository', () => {
+  it('chama prisma com filtros e paginacao', async () => {
+    await buscarColaboradores({ page: 2, perPage: 5, nome: 'test' } as any)
+    expect(prisma.usuario.findMany).toHaveBeenCalledWith({
+      where: { funcao: 'COLABORADOR', nome: { contains: 'test', mode: 'insensitive' } },
+      skip: 5,
+      take: 5
+    })
+    expect(prisma.usuario.count).toHaveBeenCalledWith({
+      where: { funcao: 'COLABORADOR', nome: { contains: 'test', mode: 'insensitive' } }
+    })
+  })
+})

--- a/src/backend/repositories/colaboradores/buscarColaboradores.repository.ts
+++ b/src/backend/repositories/colaboradores/buscarColaboradores.repository.ts
@@ -1,0 +1,16 @@
+import { prisma } from '@backend/prisma/client'
+import { BuscarColaboradoresInput } from '@backend/shared/validators/buscarColaboradores'
+
+export async function buscarColaboradores({ page, perPage, nome }: BuscarColaboradoresInput) {
+  const where: any = { funcao: 'COLABORADOR' }
+  if (nome) {
+    where.nome = { contains: nome, mode: 'insensitive' }
+  }
+
+  const [colaboradores, total] = await Promise.all([
+    prisma.usuario.findMany({ where, skip: (page - 1) * perPage, take: perPage }),
+    prisma.usuario.count({ where })
+  ])
+
+  return { colaboradores, total }
+}

--- a/src/backend/shared/validators/buscarColaboradores.ts
+++ b/src/backend/shared/validators/buscarColaboradores.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const buscarColaboradoresSchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  perPage: z.coerce.number().int().positive().max(100).default(10),
+  nome: z.string().optional()
+})
+
+export type BuscarColaboradoresInput = z.infer<typeof buscarColaboradoresSchema>

--- a/src/backend/tests/buscarColaboradores.e2e.spec.ts
+++ b/src/backend/tests/buscarColaboradores.e2e.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../../app/api/colaboradores/buscar/route'
+
+vi.mock('@backend/usecases/colaboradores/buscarColaboradores.usecase', () => {
+  return {
+    buscarColaboradoresUsecase: vi.fn().mockResolvedValue({ colaboradores: [], total: 0 })
+  }
+})
+
+import { buscarColaboradoresUsecase } from '@backend/usecases/colaboradores/buscarColaboradores.usecase'
+
+describe('GET /api/colaboradores/buscar', () => {
+  it('retorna 200 e chama usecase', async () => {
+    const url = new URL('http://localhost/api/colaboradores/buscar?page=1&perPage=10&nome=joao')
+    const req = new Request(url.toString())
+    const res = await GET(req as any)
+    expect(res.status).toBe(200)
+    expect(buscarColaboradoresUsecase).toHaveBeenCalledWith({
+      page: '1',
+      perPage: '10',
+      nome: 'joao'
+    })
+  })
+})

--- a/src/backend/usecases/colaboradores/__tests__/buscarColaboradores.usecase.spec.ts
+++ b/src/backend/usecases/colaboradores/__tests__/buscarColaboradores.usecase.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@backend/repositories/colaboradores/buscarColaboradores.repository', () => ({
+  buscarColaboradores: vi.fn()
+}))
+
+import { buscarColaboradores } from '@backend/repositories/colaboradores/buscarColaboradores.repository'
+import { buscarColaboradoresUsecase } from '../buscarColaboradores.usecase'
+
+describe('buscarColaboradoresUsecase', () => {
+  it('valida dados e chama repositorio', async () => {
+    const spy = vi.mocked(buscarColaboradores)
+    spy.mockResolvedValue({ colaboradores: [], total: 0 })
+    await buscarColaboradoresUsecase({ page: '2', perPage: '5', nome: 'abc' } as any)
+    expect(spy).toHaveBeenCalledWith({ page: 2, perPage: 5, nome: 'abc' })
+  })
+})

--- a/src/backend/usecases/colaboradores/buscarColaboradores.usecase.ts
+++ b/src/backend/usecases/colaboradores/buscarColaboradores.usecase.ts
@@ -1,0 +1,7 @@
+import { buscarColaboradores } from '@backend/repositories/colaboradores/buscarColaboradores.repository'
+import { BuscarColaboradoresInput, buscarColaboradoresSchema } from '@backend/shared/validators/buscarColaboradores'
+
+export async function buscarColaboradoresUsecase(input: BuscarColaboradoresInput) {
+  const data = buscarColaboradoresSchema.parse(input)
+  return buscarColaboradores(data)
+}


### PR DESCRIPTION
## Summary
- add schema and repository to search collaborators
- create use case and API route for collaborators listing
- test collaborators listing flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a38730da74832bbbfd6ba46794d6ca