### PR TITLE
List all users with roles

### DIFF
--- a/src/app/(protected)/dashboard/tarefas/components/add-task-dialog.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/add-task-dialog.tsx
@@ -71,7 +71,10 @@ export function AddTaskDialog() {
         fetch('/api/tipos/buscar?page=1&perPage=100').then((r) => r.json()),
       ])
 
-      const usuariosOptions = usuariosRes.colaboradores.map((u: any) => ({ value: u.id, label: u.nome }))
+      const usuariosOptions = usuariosRes.colaboradores.map((u: any) => ({
+        value: u.id,
+        label: `${u.nome} (${u.funcao})`,
+      }))
       const associacoesOptions = associacoesRes.associacoes.map((a: any) => ({ value: a.id, label: a.nome }))
       const tiposOptions = tiposRes.tipos.map((t: any) => ({ value: t.id, label: t.nome }))
 

--- a/src/backend/repositories/colaboradores/__tests__/buscarColaboradores.repository.spec.ts
+++ b/src/backend/repositories/colaboradores/__tests__/buscarColaboradores.repository.spec.ts
@@ -16,12 +16,13 @@ describe('buscarColaboradores.repository', () => {
   it('chama prisma com filtros e paginacao', async () => {
     await buscarColaboradores({ page: 2, perPage: 5, nome: 'test' } as any)
     expect(prisma.usuario.findMany).toHaveBeenCalledWith({
-      where: { funcao: 'COLABORADOR', nome: { contains: 'test', mode: 'insensitive' } },
+      where: { funcao: { in: ['COLABORADOR', 'ADM'] }, nome: { contains: 'test', mode: 'insensitive' } },
+      select: { id: true, nome: true, funcao: true },
       skip: 5,
       take: 5
     })
     expect(prisma.usuario.count).toHaveBeenCalledWith({
-      where: { funcao: 'COLABORADOR', nome: { contains: 'test', mode: 'insensitive' } }
+      where: { funcao: { in: ['COLABORADOR', 'ADM'] }, nome: { contains: 'test', mode: 'insensitive' } }
     })
   })
 })

--- a/src/backend/repositories/colaboradores/buscarColaboradores.repository.ts
+++ b/src/backend/repositories/colaboradores/buscarColaboradores.repository.ts
@@ -2,13 +2,18 @@ import { prisma } from '@backend/prisma/client'
 import { BuscarColaboradoresInput } from '@backend/shared/validators/buscarColaboradores'
 
 export async function buscarColaboradores({ page, perPage, nome }: BuscarColaboradoresInput) {
-  const where: any = { funcao: 'COLABORADOR' }
+  const where: any = { funcao: { in: ['COLABORADOR', 'ADM'] } }
   if (nome) {
     where.nome = { contains: nome, mode: 'insensitive' }
   }
 
   const [colaboradores, total] = await Promise.all([
-    prisma.usuario.findMany({ where, skip: (page - 1) * perPage, take: perPage }),
+    prisma.usuario.findMany({
+      where,
+      select: { id: true, nome: true, funcao: true },
+      skip: (page - 1) * perPage,
+      take: perPage,
+    }),
     prisma.usuario.count({ where })
   ])
 


### PR DESCRIPTION
## Summary
- include admins when fetching users and return name with role
- show user role in add-task dialog dropdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a392586c0c832b930346af1ffc817a