### PR TITLE
Use logged user and default status for task creation

### DIFF
--- a/src/app/(protected)/dashboard/tarefas/components/add-task-dialog.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/add-task-dialog.tsx
@@ -25,6 +25,7 @@ import {
   SelectItem,
 } from '@/components/ui/select'
 import { priorities } from './data'
+import { createClient } from '@/lib/client'
 import {
   Form,
   FormField,
@@ -97,6 +98,15 @@ export function AddTaskDialog() {
     setIsLoading(true)
     setError(null)
     try {
+      const supabase = createClient()
+      const {
+        data: { user }
+      } = await supabase.auth.getUser()
+
+      if (!user) {
+        throw new Error('Usuário não autenticado')
+      }
+
       const res = await fetch('/api/tarefas/criar', {
         method: 'POST',
         headers: {
@@ -110,7 +120,9 @@ export function AddTaskDialog() {
           associacaoId: data.associacao,
           tipoId: data.tipo,
           data_fim: data.dataFim,
-          statusId: 'todo'
+          statusId: null,
+          criadorId: user.id,
+          data_inicio: new Date()
         })
       })
       if (!res.ok) {

--- a/src/backend/entities/tarefa.ts
+++ b/src/backend/entities/tarefa.ts
@@ -6,7 +6,7 @@ export interface Tarefa {
   associacaoId: string
   criadorId: string
   responsavelId: string
-  statusId: string
+  statusId: string | null
   tipoId: string
   data_inicio: Date
   data_fim: Date

--- a/src/backend/shared/validators/tarefa.ts
+++ b/src/backend/shared/validators/tarefa.ts
@@ -7,7 +7,7 @@ export const tarefaSchema = z.object({
   associacaoId: z.string().uuid(),
   criadorId: z.string().uuid(),
   responsavelId: z.string().uuid(),
-  statusId: z.string().uuid(),
+  statusId: z.string().uuid().nullish(),
   tipoId: z.string().uuid(),
   data_inicio: z.coerce.date(),
   data_fim: z.coerce.date()

--- a/src/backend/usecases/tarefas/__tests__/criarTarefa.usecase.spec.ts
+++ b/src/backend/usecases/tarefas/__tests__/criarTarefa.usecase.spec.ts
@@ -18,7 +18,7 @@ describe('criarTarefaUsecase', () => {
       associacaoId: '00000000-0000-0000-0000-000000000000',
       criadorId: '00000000-0000-0000-0000-000000000000',
       responsavelId: '00000000-0000-0000-0000-000000000000',
-      statusId: '00000000-0000-0000-0000-000000000000',
+      statusId: null,
       tipoId: '00000000-0000-0000-0000-000000000000',
       data_inicio: new Date(),
       data_fim: new Date()


### PR DESCRIPTION
## Summary
- derive `criadorId` from the logged-in user
- send `statusId` as null and update validator/types to accept it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a0988784832bb987ae311aaeadb6