### PR TITLE
Fix Prisma field mapping for task creation

### DIFF
--- a/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
@@ -8,9 +8,32 @@ vi.mock('@backend/prisma/client', () => {
 
 describe('criarTarefa.repository', () => {
   it('insere tarefa com prisma', async () => {
-    const data: any = { titulo: 't' }
+    const data: any = {
+      titulo: 't',
+      descricao: 'd',
+      prioridade: 'p',
+      associacaoId: 'a',
+      criadorId: 'c',
+      responsavelId: 'r',
+      statusId: null,
+      tipoId: 't',
+      data_inicio: new Date('2024-01-01'),
+      data_fim: new Date('2024-01-02'),
+    }
     const result = await criarTarefa(data)
-    expect(prisma.tarefa.create).toHaveBeenCalledWith({ data })
+    expect(prisma.tarefa.create).toHaveBeenCalledWith({
+      data: {
+        titulo: data.titulo,
+        descricao: data.descricao,
+        prioridade: data.prioridade,
+        associacaoid: data.associacaoId,
+        criadorid: data.criadorId,
+        responsavelid: data.responsavelId,
+        tipoid: data.tipoId,
+        data_inicio: data.data_inicio,
+        data_fim: data.data_fim,
+      },
+    })
     expect(result).toEqual({ id: '1' })
   })
 })

--- a/src/backend/repositories/tarefas/criarTarefa.repository.ts
+++ b/src/backend/repositories/tarefas/criarTarefa.repository.ts
@@ -3,5 +3,18 @@ import { TarefaInput } from '@backend/shared/validators/tarefa'
 import { prisma } from '@backend/prisma/client'
 
 export function criarTarefa(data: TarefaInput) {
-  return prisma.tarefa.create({ data })
+  return prisma.tarefa.create({
+    data: {
+      titulo: data.titulo,
+      descricao: data.descricao,
+      prioridade: data.prioridade,
+      associacaoid: data.associacaoId,
+      criadorid: data.criadorId,
+      responsavelid: data.responsavelId,
+      ...(data.statusId ? { statusid: data.statusId } : {}),
+      tipoid: data.tipoId,
+      data_inicio: data.data_inicio,
+      data_fim: data.data_fim,
+    },
+  })
 }


### PR DESCRIPTION
## Summary
- map task relationship IDs to Prisma fields in criarTarefa repository
- adjust repository test for new mapping

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3b76a366c832baa93c9652c81723f