### PR TITLE
Handle Prisma FK error target

### DIFF
--- a/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
@@ -45,4 +45,10 @@ describe('criarTarefa.repository', () => {
     vi.mocked(prisma.tarefa.create).mockRejectedValue(prismaError as any)
     await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)
   })
+
+  it('lança AppError quando responsavel não existe (meta.target)', async () => {
+    const prismaError = { code: 'P2003', meta: { target: 'tarefa_responsavelid_fkey' } }
+    vi.mocked(prisma.tarefa.create).mockRejectedValue(prismaError as any)
+    await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)
+  })
 })

--- a/src/backend/repositories/tarefas/criarTarefa.repository.ts
+++ b/src/backend/repositories/tarefas/criarTarefa.repository.ts
@@ -20,7 +20,10 @@ export async function criarTarefa(data: TarefaInput) {
       },
     })
   } catch (error: any) {
-    if (error?.code === 'P2003' && error?.meta?.field_name?.includes('responsavelid')) {
+    if (
+      error?.code === 'P2003' &&
+      (error?.meta?.field_name || error?.meta?.target)?.toLowerCase?.().includes('responsavelid')
+    ) {
       throw new AppError('Responsável não encontrado')
     }
     throw error


### PR DESCRIPTION
## Summary
- handle Prisma FK error when responsavel not found by checking meta field_name or target
- test for FK error meta.target

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3be2ac384832b80b810dda64dbeaf