### PR TITLE
Handle foreign key violation for task creator

### DIFF
--- a/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
@@ -65,4 +65,12 @@ describe('criarTarefa.repository', () => {
     vi.mocked(prisma.tarefa.create).mockRejectedValue(prismaError as any)
     await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)
   })
+
+  it('lança AppError quando prisma retorna P2003 de criadorid', async () => {
+    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'creator' } as any)
+    vi.mocked(prisma.usuario.findFirst).mockResolvedValue({ id: 'responsavel' } as any)
+    const prismaError = { code: 'P2003', meta: { field_name: 'tarefa_criadorid_fkey' } }
+    vi.mocked(prisma.tarefa.create).mockRejectedValue(prismaError as any)
+    await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)
+  })
 })

--- a/src/backend/repositories/tarefas/criarTarefa.repository.ts
+++ b/src/backend/repositories/tarefas/criarTarefa.repository.ts
@@ -38,11 +38,16 @@ export async function criarTarefa(data: TarefaInput) {
     if (error instanceof AppError) {
       throw error
     }
-    if (
-      error?.code === 'P2003' &&
-      (error?.meta?.field_name || error?.meta?.target)?.toLowerCase?.().includes('responsavelid')
-    ) {
-      throw new AppError('Responsável não encontrado')
+    const fieldName = (error?.meta?.field_name || error?.meta?.target || '').toLowerCase()
+
+    if (error?.code === 'P2003') {
+      if (fieldName.includes('responsavelid')) {
+        throw new AppError('Responsável não encontrado')
+      }
+
+      if (fieldName.includes('criadorid')) {
+        throw new AppError('Criador não encontrado')
+      }
     }
 
     throw error


### PR DESCRIPTION
## Summary
- handle P2003 errors for `criadorid` in `criarTarefa.repository`
- add unit test covering creator foreign key violation

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c99c0554832bac63a66410d2da13