### PR TITLE
fix: validate responsavel on task creation

### DIFF
--- a/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
@@ -27,8 +27,8 @@ describe('criarTarefa.repository', () => {
   }
 
   it('insere tarefa com prisma', async () => {
-    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'creator' } as any)
-    vi.mocked(prisma.usuario.findFirst).mockResolvedValue({ id: 'responsavel' } as any)
+    vi.mocked(prisma.usuario.findFirst).mockResolvedValue({ id: 'creator' } as any)
+    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as any)
     vi.mocked(prisma.tarefa.create).mockResolvedValue({ id: '1' } as any)
     const result = await criarTarefa(data)
     expect(prisma.tarefa.create).toHaveBeenCalledWith({
@@ -48,27 +48,27 @@ describe('criarTarefa.repository', () => {
   })
 
   it('lança AppError quando responsavel não existe', async () => {
-    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'creator' } as any)
-    vi.mocked(prisma.usuario.findFirst).mockResolvedValue(null)
-    await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)
-  })
-
-  it('lança AppError quando criador não existe', async () => {
+    vi.mocked(prisma.usuario.findFirst).mockResolvedValue({ id: 'creator' } as any)
     vi.mocked(prisma.usuario.findUnique).mockResolvedValue(null)
     await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)
   })
 
+  it('lança AppError quando criador não existe', async () => {
+    vi.mocked(prisma.usuario.findFirst).mockResolvedValue(null)
+    await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)
+  })
+
   it('lança AppError quando prisma retorna P2003 de responsavelid', async () => {
-    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'creator' } as any)
-    vi.mocked(prisma.usuario.findFirst).mockResolvedValue({ id: 'responsavel' } as any)
+    vi.mocked(prisma.usuario.findFirst).mockResolvedValue({ id: 'creator' } as any)
+    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as any)
     const prismaError = { code: 'P2003', meta: { field_name: 'tarefa_responsavelid_fkey' } }
     vi.mocked(prisma.tarefa.create).mockRejectedValue(prismaError as any)
     await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)
   })
 
   it('lança AppError quando prisma retorna P2003 de criadorid', async () => {
-    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'creator' } as any)
-    vi.mocked(prisma.usuario.findFirst).mockResolvedValue({ id: 'responsavel' } as any)
+    vi.mocked(prisma.usuario.findFirst).mockResolvedValue({ id: 'creator' } as any)
+    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as any)
     const prismaError = { code: 'P2003', meta: { field_name: 'tarefa_criadorid_fkey' } }
     vi.mocked(prisma.tarefa.create).mockRejectedValue(prismaError as any)
     await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)


### PR DESCRIPTION
## Summary
- ensure both creator and responsible users exist before creating task
- update repository tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a45eca2480832b8738b17ff461ba08