### PR TITLE
feat: add tarefa delete endpoint

### DIFF
--- a/src/app/api/tarefas/README.md
+++ b/src/app/api/tarefas/README.md
@@ -1,1 +1,5 @@
 Endpoints for task (tarefa) management.
+
+- `POST /api/tarefas/criar` – cria uma nova tarefa
+- `GET /api/tarefas/buscar` – lista tarefas
+- `DELETE /api/tarefas/deletar` – remove uma tarefa

--- a/src/app/api/tarefas/deletar/route.ts
+++ b/src/app/api/tarefas/deletar/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { deletarTarefaUsecase } from '@backend/usecases/tarefas/deletarTarefa.usecase'
+import { AppError } from '@backend/shared/errors/app-error'
+
+export async function DELETE(request: NextRequest) {
+  const data = await request.json()
+  try {
+    await deletarTarefaUsecase(data)
+    return NextResponse.json({ message: 'Tarefa deletada com sucesso' }, { status: 200 })
+  } catch (error) {
+    if (error instanceof AppError) {
+      return NextResponse.json({ message: error.message }, { status: 400 })
+    }
+    console.log(error)
+    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 })
+  }
+}

--- a/src/backend/repositories/tarefas/__tests__/deletarTarefa.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/deletarTarefa.repository.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest'
+import { deletarTarefa } from '../deletarTarefa.repository'
+import { prisma } from '@backend/prisma/client'
+import { AppError } from '@backend/shared/errors/app-error'
+
+vi.mock('@backend/prisma/client', () => ({
+  prisma: {
+    tarefa: { delete: vi.fn() }
+  }
+}))
+
+describe('deletarTarefa.repository', () => {
+  it('deleta tarefa pelo id', async () => {
+    vi.mocked(prisma.tarefa.delete).mockResolvedValue({ id: '1' } as any)
+    const result = await deletarTarefa('1')
+    expect(prisma.tarefa.delete).toHaveBeenCalledWith({ where: { id: '1' } })
+    expect(result).toEqual({ id: '1' })
+  })
+
+  it('lança AppError quando tarefa não existe', async () => {
+    const error = { code: 'P2025' }
+    vi.mocked(prisma.tarefa.delete).mockRejectedValue(error as any)
+    await expect(deletarTarefa('1')).rejects.toBeInstanceOf(AppError)
+  })
+})

--- a/src/backend/repositories/tarefas/deletarTarefa.repository.ts
+++ b/src/backend/repositories/tarefas/deletarTarefa.repository.ts
@@ -1,0 +1,13 @@
+import { prisma } from '@backend/prisma/client'
+import { AppError } from '@backend/shared/errors/app-error'
+
+export async function deletarTarefa(id: string) {
+  try {
+    return await prisma.tarefa.delete({ where: { id } })
+  } catch (error: any) {
+    if (error?.code === 'P2025') {
+      throw new AppError('Tarefa não encontrada')
+    }
+    throw error
+  }
+}

--- a/src/backend/shared/validators/deletarTarefa.ts
+++ b/src/backend/shared/validators/deletarTarefa.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const deletarTarefaSchema = z.object({
+  id: z.string().uuid()
+})
+
+export type DeletarTarefaInput = z.infer<typeof deletarTarefaSchema>

--- a/src/backend/usecases/tarefas/__tests__/deletarTarefa.usecase.spec.ts
+++ b/src/backend/usecases/tarefas/__tests__/deletarTarefa.usecase.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@backend/repositories/tarefas/deletarTarefa.repository', () => ({
+  deletarTarefa: vi.fn()
+}))
+
+import { deletarTarefa } from '@backend/repositories/tarefas/deletarTarefa.repository'
+import { deletarTarefaUsecase } from '../deletarTarefa.usecase'
+
+describe('deletarTarefaUsecase', () => {
+  it('valida dados e chama repositorio', async () => {
+    const spy = vi.mocked(deletarTarefa)
+    spy.mockResolvedValue({} as any)
+    await deletarTarefaUsecase({ id: '00000000-0000-0000-0000-000000000000' })
+    expect(spy).toHaveBeenCalledWith('00000000-0000-0000-0000-000000000000')
+  })
+})

--- a/src/backend/usecases/tarefas/deletarTarefa.usecase.ts
+++ b/src/backend/usecases/tarefas/deletarTarefa.usecase.ts
@@ -1,0 +1,7 @@
+import { deletarTarefa } from '@backend/repositories/tarefas/deletarTarefa.repository'
+import { DeletarTarefaInput, deletarTarefaSchema } from '@backend/shared/validators/deletarTarefa'
+
+export async function deletarTarefaUsecase(input: DeletarTarefaInput) {
+  const { id } = deletarTarefaSchema.parse(input)
+  return deletarTarefa(id)
+}


### PR DESCRIPTION
## Summary
- add validator and use case for deleting tasks
- expose DELETE /api/tarefas/deletar route
- support repository deletion logic and adjust tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4f317f014832bb40ecb1e3b318175