### PR TITLE
feat: connect task deletion with API route and confirmation dialog

### DIFF
--- a/src/app/(protected)/dashboard/tarefas/components/data-table-row-actions.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/data-table-row-actions.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 
 import { labels } from "./data"
+import { useRouter } from "next/navigation"
 
 interface DataTableRowActionsProps<TData> {
   row: Row<TData>
@@ -26,6 +27,29 @@ interface DataTableRowActionsProps<TData> {
 
 export function DataTableRowActions<TData>({ row }: DataTableRowActionsProps<TData>) {
   const task = row.original as any
+  const router = useRouter()
+
+  const handleDelete = async () => {
+    const confirmed = window.confirm("Deseja realmente excluir esta tarefa?")
+    if (!confirmed) return
+
+    try {
+      const baseUrl = process.env.NEXT_PUBLIC_API_URL || ""
+      const res = await fetch(`${baseUrl}/api/tarefas/deletar`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: task.id }),
+      })
+
+      if (res.ok) {
+        router.refresh()
+      } else {
+        console.error("Falha ao excluir tarefa")
+      }
+    } catch (error) {
+      console.error("Erro ao excluir tarefa", error)
+    }
+  }
 
   return (
     <DropdownMenu>
@@ -53,7 +77,7 @@ export function DataTableRowActions<TData>({ row }: DataTableRowActionsProps<TDa
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         <DropdownMenuSeparator />
-        <DropdownMenuItem variant="destructive">
+        <DropdownMenuItem variant="destructive" onClick={handleDelete}>
           Excluir
           <DropdownMenuShortcut>⌘⌫</DropdownMenuShortcut>
         </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- confirm before deleting tasks
- call API to remove task and refresh table

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4f93d7774832bb6b25380fe64bc82