### PR TITLE
Atualiza lista de tarefas após operações

### DIFF
--- a/src/app/(protected)/dashboard/tarefas/components/add-task-dialog.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/add-task-dialog.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { Loader2 } from 'lucide-react'
 import { z } from 'zod'
 import { useForm } from 'react-hook-form'
@@ -52,6 +53,7 @@ export function AddTaskDialog() {
   const [tipos, setTipos] = useState<{ value: string; label: string }[]>([])
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  const router = useRouter()
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -131,6 +133,7 @@ export function AddTaskDialog() {
       }
       setOpen(false)
       form.reset()
+      router.refresh()
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Erro ao criar tarefa')
     } finally {

--- a/src/app/(protected)/dashboard/tarefas/components/edit-task-dialog.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/edit-task-dialog.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, ReactNode } from 'react'
+import { useRouter } from 'next/navigation'
 import { Loader2 } from 'lucide-react'
 import { z } from 'zod'
 import { useForm } from 'react-hook-form'
@@ -58,6 +59,7 @@ export function EditTaskDialog({ task, children }: EditTaskDialogProps) {
   const [tipos, setTipos] = useState<{ value: string; label: string }[]>([])
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  const router = useRouter()
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -149,6 +151,7 @@ export function EditTaskDialog({ task, children }: EditTaskDialogProps) {
         throw new Error(errData.message || 'Erro ao editar tarefa')
       }
       setOpen(false)
+      router.refresh()
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Erro ao editar tarefa')
     } finally {


### PR DESCRIPTION
## Summary
- Atualiza tabela após criar nova tarefa
- Recarrega listagem ao editar tarefa existente

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5b4195828832bbfa551dde144cd4e