### PR TITLE
Corrigir exibição do status na tabela de tarefas

### DIFF
--- a/src/app/(protected)/dashboard/tarefas/components/columns.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/columns.tsx
@@ -87,8 +87,9 @@ export const columns: ColumnDef<Task>[] = [
       <DataTableColumnHeader column={column} title="Status" className="w-fit" />
     ),
     cell: ({ row }) => {
-      const status = statuses.find((status) => status.value === row.getValue("status"))
-      if (!status) return null
+      const value = row.getValue("status") as string | null
+      const status = statuses.find((status) => status.value === value)
+      if (!status) return <span>{value ?? "-"}</span>
       return (
         <div className="flex items-center gap-2 w-fit">
           {status.icon && <status.icon className="text-muted-foreground size-4" />}

--- a/src/app/(protected)/dashboard/tarefas/components/data.ts
+++ b/src/app/(protected)/dashboard/tarefas/components/data.ts
@@ -26,27 +26,27 @@ export const labels = [
 
 export const statuses = [
   {
-    value: "backlog",
+    value: "Backlog",
     label: "Backlog",
     icon: HelpCircle,
   },
   {
-    value: "todo",
+    value: "A Fazer",
     label: "A Fazer",
     icon: Circle,
   },
   {
-    value: "in progress",
+    value: "Em Andamento",
     label: "Em Andamento",
     icon: Timer,
   },
   {
-    value: "done",
+    value: "Concluída",
     label: "Concluída",
     icon: CheckCircle,
   },
   {
-    value: "canceled",
+    value: "Cancelada",
     label: "Cancelada",
     icon: CircleOff,
   },

--- a/src/app/(protected)/dashboard/tarefas/page.tsx
+++ b/src/app/(protected)/dashboard/tarefas/page.tsx
@@ -34,7 +34,7 @@ export default async function TarefasPage() {
     createdAt: t.createdat,
     title: t.titulo,
     description: t.descricao,
-    status: t.statusid ?? null,
+    status: t.status?.nome ?? null,
     label: t.tipoid ?? null,
     priority: t.prioridade ?? null,
     endDate: t.data_fim ?? null,

--- a/src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts
@@ -18,7 +18,8 @@ describe('buscarTarefas.repository', () => {
     expect(prisma.tarefa.findMany).toHaveBeenCalledWith({
       where: { statusId: '1', prioridade: 'alta', titulo: { contains: 'test', mode: 'insensitive' } },
       skip: 5,
-      take: 5
+      take: 5,
+      include: { status: true }
     })
     expect(prisma.tarefa.count).toHaveBeenCalledWith({
       where: { statusId: '1', prioridade: 'alta', titulo: { contains: 'test', mode: 'insensitive' } }

--- a/src/backend/repositories/tarefas/buscarTarefas.repository.ts
+++ b/src/backend/repositories/tarefas/buscarTarefas.repository.ts
@@ -14,7 +14,12 @@ export async function buscarTarefas({ page, perPage, titulo, statusId, prioridad
   }
 
   const [tarefas, total] = await Promise.all([
-    prisma.tarefa.findMany({ where, skip: (page - 1) * perPage, take: perPage }),
+    prisma.tarefa.findMany({
+      where,
+      skip: (page - 1) * perPage,
+      take: perPage,
+      include: { status: true }
+    }),
     prisma.tarefa.count({ where })
   ])
 


### PR DESCRIPTION
## Summary
- carregar status relacionado ao buscar tarefas
- exibir nome do status na listagem de tarefas
- alinhar valores de status e ajustar testes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5b70c0130832bb47e138dc185b1a4