### PR TITLE
feat: add task notifications

### DIFF
--- a/src/app/(protected)/dashboard/tarefas/components/add-task-dialog.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/add-task-dialog.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/select'
 import { priorities } from './data'
 import { createClient } from '@/lib/client'
+import { useNotification } from '@/components/notification-provider'
 import {
   Form,
   FormField,
@@ -54,6 +55,7 @@ export function AddTaskDialog() {
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const router = useRouter()
+  const notify = useNotification()
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -131,6 +133,7 @@ export function AddTaskDialog() {
         const errData = await res.json().catch(() => ({}))
         throw new Error(errData.message || 'Erro ao criar tarefa')
       }
+      notify({ type: 'success', title: 'Tarefa', message: 'Tarefa criada com sucesso.' })
       setOpen(false)
       form.reset()
       router.refresh()

--- a/src/app/(protected)/dashboard/tarefas/components/data-table-row-actions.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/data-table-row-actions.tsx
@@ -22,6 +22,7 @@ import { labels } from "./data"
 import { EditTaskDialog } from "./edit-task-dialog"
 import { Task } from "./columns"
 import { useRouter } from "next/navigation"
+import { useNotification } from "@/components/notification-provider"
 
 interface DataTableRowActionsProps<TData> {
   row: Row<TData>
@@ -30,6 +31,7 @@ interface DataTableRowActionsProps<TData> {
 export function DataTableRowActions<TData>({ row }: DataTableRowActionsProps<TData>) {
   const task = row.original as any
   const router = useRouter()
+  const notify = useNotification()
 
   const handleDelete = async () => {
     const confirmed = window.confirm("Deseja realmente excluir esta tarefa?")
@@ -44,12 +46,13 @@ export function DataTableRowActions<TData>({ row }: DataTableRowActionsProps<TDa
       })
 
       if (res.ok) {
+        notify({ type: "success", title: "Tarefa", message: "Tarefa excluída com sucesso." })
         router.refresh()
       } else {
-        console.error("Falha ao excluir tarefa")
+        notify({ type: "error", title: "Tarefa", message: "Falha ao excluir tarefa" })
       }
     } catch (error) {
-      console.error("Erro ao excluir tarefa", error)
+      notify({ type: "error", title: "Tarefa", message: "Erro ao excluir tarefa" })
     }
   }
 

--- a/src/app/(protected)/dashboard/tarefas/components/edit-task-dialog.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/edit-task-dialog.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/select'
 import { priorities } from './data'
 import { createClient } from '@/lib/client'
+import { useNotification } from '@/components/notification-provider'
 import {
   Form,
   FormField,
@@ -60,6 +61,7 @@ export function EditTaskDialog({ task, children }: EditTaskDialogProps) {
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const router = useRouter()
+  const notify = useNotification()
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -162,6 +164,7 @@ export function EditTaskDialog({ task, children }: EditTaskDialogProps) {
         const errData = await res.json().catch(() => ({}))
         throw new Error(errData.message || 'Erro ao editar tarefa')
       }
+      notify({ type: 'success', title: 'Tarefa', message: 'Tarefa editada com sucesso.' })
       setOpen(false)
       router.refresh()
     } catch (e) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import type React from "react";
+import { NotificationProvider } from "@/components/notification-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,7 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <NotificationProvider>{children}</NotificationProvider>
       </body>
     </html>
   );

--- a/src/components/notification-provider.tsx
+++ b/src/components/notification-provider.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { createContext, useContext, useState, useCallback, ReactNode } from "react"
+import { CheckCircle2, AlertCircle } from "lucide-react"
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert"
+
+type Notification = {
+  type: "success" | "error"
+  title?: string
+  message: string
+}
+
+type NotifyFn = (n: Notification) => void
+
+const NotificationContext = createContext<NotifyFn | null>(null)
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  const [notification, setNotification] = useState<Notification | null>(null)
+
+  const notify = useCallback<NotifyFn>((n) => {
+    setNotification(n)
+    setTimeout(() => setNotification(null), 3000)
+  }, [])
+
+  return (
+    <NotificationContext.Provider value={notify}>
+      {notification && (
+        <div className="fixed top-4 right-4 z-50 w-80">
+          <Alert variant={notification.type === "error" ? "destructive" : "success"}>
+            {notification.type === "error" ? (
+              <AlertCircle className="h-4 w-4" />
+            ) : (
+              <CheckCircle2 className="h-4 w-4" />
+            )}
+            {notification.title && <AlertTitle>{notification.title}</AlertTitle>}
+            <AlertDescription>{notification.message}</AlertDescription>
+          </Alert>
+        </div>
+      )}
+      {children}
+    </NotificationContext.Provider>
+  )
+}
+
+export function useNotification() {
+  const ctx = useContext(NotificationContext)
+  if (!ctx) throw new Error("useNotification must be used within NotificationProvider")
+  return ctx
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+        success:
+          "border-green-500/50 text-green-600 dark:border-green-500 [&>svg]:text-green-600",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface AlertProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof alertVariants> {}
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, variant, ...props }, ref) => (
+    <div
+      ref={ref}
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+)
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("text-sm [&_p]:leading-relaxed", className)} {...props} />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }


### PR DESCRIPTION
## Summary
- create alert component with success variant and notification provider
- show success notifications when creating, editing or deleting tasks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a613798d28832b9713966c4aa53dea