### PR TITLE
Fix responsible selection when editing tasks

### DIFF
--- a/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
@@ -27,7 +27,7 @@ describe('criarTarefa.repository', () => {
   }
 
   it('insere tarefa com prisma', async () => {
-    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ user_id: 'responsavel' } as any)
+    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as any)
     vi.mocked(prisma.tarefa.create).mockResolvedValue({ id: '1' } as any)
     const result = await criarTarefa(data)
     expect(prisma.tarefa.create).toHaveBeenCalledWith({
@@ -37,7 +37,7 @@ describe('criarTarefa.repository', () => {
         prioridade: data.prioridade,
         associacaoid: data.associacaoId,
         criadorid: data.criadorId,
-        responsavelid: 'responsavel',
+        responsavelid: data.responsavelId,
         tipoid: data.tipoId,
         statusid: '8eb90bc1-244c-4412-bc9f-3c12097a8d83',
         data_inicio: data.data_inicio,
@@ -53,14 +53,14 @@ describe('criarTarefa.repository', () => {
   })
 
   it('lança AppError quando prisma retorna P2003 de responsavelid', async () => {
-    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ user_id: 'responsavel' } as any)
+    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as any)
     const prismaError = { code: 'P2003', meta: { field_name: 'tarefa_responsavelid_fkey' } }
     vi.mocked(prisma.tarefa.create).mockRejectedValue(prismaError as any)
     await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)
   })
 
   it('lança AppError quando prisma retorna P2003 de criadorid', async () => {
-    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ user_id: 'responsavel' } as any)
+    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as any)
     const prismaError = { code: 'P2003', meta: { field_name: 'tarefa_criadorid_fkey' } }
     vi.mocked(prisma.tarefa.create).mockRejectedValue(prismaError as any)
     await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)

--- a/src/backend/repositories/tarefas/criarTarefa.repository.ts
+++ b/src/backend/repositories/tarefas/criarTarefa.repository.ts
@@ -14,8 +14,6 @@ export async function criarTarefa(data: TarefaInput) {
     if (!responsavel) {
       throw new AppError('Responsável não encontrado')
     }
-    console.log('Criando tarefa com os dados:', data)
-    console.log('Responsável encontrado:', responsavel)
 
     return await prisma.tarefa.create({
       data: {
@@ -24,7 +22,7 @@ export async function criarTarefa(data: TarefaInput) {
         prioridade: data.prioridade,
         associacaoid: data.associacaoId,
         criadorid: data.criadorId,
-        responsavelid: responsavel.user_id,
+        responsavelid: data.responsavelId,
         tipoid: data.tipoId,
         statusid: '8eb90bc1-244c-4412-bc9f-3c12097a8d83', // ID do status "Em andamento"
         data_inicio: data.data_inicio,

--- a/src/backend/repositories/tarefas/editarTarefa.repository.ts
+++ b/src/backend/repositories/tarefas/editarTarefa.repository.ts
@@ -12,7 +12,7 @@ export async function editarTarefa(data: EditarTarefaInput) {
       if (!responsavel) {
         throw new AppError('Responsável não encontrado')
       }
-      responsavelid = responsavel.user_id
+      responsavelid = data.responsavelId
     }
 
     return await prisma.tarefa.update({


### PR DESCRIPTION
## Summary
- store task responsible using the application's user ID
- keep editing logic aligned with new responsible ID
- update repository tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a613d72420832bbec7b2742a473c95