### PR TITLE
fix: ensure valid responsible id when creating task

### DIFF
--- a/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
@@ -37,7 +37,8 @@ describe('criarTarefa.repository', () => {
         prioridade: data.prioridade,
         associacaoid: data.associacaoId,
         criadorid: data.criadorId,
-        responsavelid: data.responsavelId,
+        // o id salvo deve ser o retornado do banco
+        responsavelid: 'responsavel',
         tipoid: data.tipoId,
         statusid: '8eb90bc1-244c-4412-bc9f-3c12097a8d83',
         data_inicio: data.data_inicio,

--- a/src/backend/repositories/tarefas/criarTarefa.repository.ts
+++ b/src/backend/repositories/tarefas/criarTarefa.repository.ts
@@ -22,7 +22,8 @@ export async function criarTarefa(data: TarefaInput) {
         prioridade: data.prioridade,
         associacaoid: data.associacaoId,
         criadorid: data.criadorId,
-        responsavelid: data.responsavelId,
+        // utilize o id retornado do banco para evitar inconsistências de FK
+        responsavelid: responsavel.id,
         tipoid: data.tipoId,
         statusid: '8eb90bc1-244c-4412-bc9f-3c12097a8d83', // ID do status "Em andamento"
         data_inicio: data.data_inicio,


### PR DESCRIPTION
## Summary
- ensure task creation uses responsible id from database
- update repository tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a62671a128832bbec59043c3998aee