### PR TITLE
Ajusta repositórios de tarefas para novo schema

### DIFF
--- a/src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts
@@ -16,13 +16,13 @@ describe('buscarTarefas.repository', () => {
   it('chama prisma com filtros e paginacao', async () => {
     await buscarTarefas({ page: 2, perPage: 5, statusId: '1', titulo: 'test', prioridade: 'alta' } as any)
     expect(prisma.tarefa.findMany).toHaveBeenCalledWith({
-      where: { statusId: '1', prioridade: 'alta', titulo: { contains: 'test', mode: 'insensitive' } },
+      where: { statusid: '1', prioridade: 'alta', titulo: { contains: 'test', mode: 'insensitive' } },
       skip: 5,
       take: 5,
       include: { status: true }
     })
     expect(prisma.tarefa.count).toHaveBeenCalledWith({
-      where: { statusId: '1', prioridade: 'alta', titulo: { contains: 'test', mode: 'insensitive' } }
+      where: { statusid: '1', prioridade: 'alta', titulo: { contains: 'test', mode: 'insensitive' } }
     })
   })
 })

--- a/src/backend/repositories/tarefas/buscarTarefas.repository.ts
+++ b/src/backend/repositories/tarefas/buscarTarefas.repository.ts
@@ -7,7 +7,8 @@ export async function buscarTarefas({ page, perPage, titulo, statusId, prioridad
     where.titulo = { contains: titulo, mode: 'insensitive' }
   }
   if (statusId) {
-    where.statusId = statusId
+    // o campo na tabela é `statusid`, ajustado para refletir o novo schema
+    where.statusid = statusId
   }
   if (prioridade) {
     where.prioridade = prioridade

--- a/src/backend/repositories/tarefas/criarTarefa.repository.ts
+++ b/src/backend/repositories/tarefas/criarTarefa.repository.ts
@@ -5,7 +5,7 @@ import { AppError } from '@backend/shared/errors/app-error'
 
 export async function criarTarefa(data: TarefaInput) {
   try {
-    const responsavel = await prisma.usuario.findFirst({
+    const responsavel = await prisma.usuario.findUnique({
       where: {
         id: data.responsavelId,
       },
@@ -23,7 +23,7 @@ export async function criarTarefa(data: TarefaInput) {
         associacaoid: data.associacaoId,
         criadorid: data.criadorId,
         // utilize o id retornado do banco para evitar inconsistências de FK
-        responsavelid: responsavel.user_id,
+        responsavelid: responsavel.id,
         tipoid: data.tipoId,
         statusid: '8eb90bc1-244c-4412-bc9f-3c12097a8d83', // ID do status "Em andamento"
         data_inicio: data.data_inicio,


### PR DESCRIPTION
## Summary
- Usa `findUnique` em vez de `findFirst` ao buscar responsável
- Adapta busca de tarefas ao campo `statusid` do novo schema
- Atualiza testes para refletir os novos nomes de campos

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ace0d83444832b8808dd933124f21c