### PR TITLE
refactor: unify API route handlers

### DIFF
--- a/src/app/api/associacoes/buscar/route.ts
+++ b/src/app/api/associacoes/buscar/route.ts
@@ -1,11 +1,30 @@
+import { NextResponse } from 'next/server'
+import { ZodError } from 'zod'
 import { buscarAssociacoesUsecase } from '@backend/usecases/associacoes/buscarAssociacoes.usecase'
+import { buscarAssociacoesSchema } from '@backend/shared/validators/buscarAssociacoes'
+import { AppError } from '@backend/shared/errors/app-error'
 
-export async function GET(req: Request) {
-  const url = new URL(req.url)
-  const params = Object.fromEntries(url.searchParams.entries())
-  const result = await buscarAssociacoesUsecase(params as any)
-  return new Response(JSON.stringify(result), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' }
-  })
+const safeJson = (data: unknown) =>
+  JSON.parse(
+    JSON.stringify(data, (_, value) =>
+      typeof value === 'bigint' ? value.toString() : value
+    )
+  )
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url)
+    const params = buscarAssociacoesSchema.parse(
+      Object.fromEntries(url.searchParams.entries())
+    )
+    const result = await buscarAssociacoesUsecase(params)
+    return NextResponse.json(safeJson(result))
+  } catch (error) {
+    console.error('GET /api/associacoes/buscar', error)
+    if (error instanceof ZodError || error instanceof AppError) {
+      return NextResponse.json({ message: error.message }, { status: 400 })
+    }
+    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 })
+  }
 }
+

--- a/src/app/api/tarefas/buscar/route.ts
+++ b/src/app/api/tarefas/buscar/route.ts
@@ -1,11 +1,30 @@
+import { NextResponse } from 'next/server'
+import { ZodError } from 'zod'
 import { buscarTarefasUsecase } from '@backend/usecases/tarefas/buscarTarefas.usecase'
+import { buscarTarefasSchema } from '@backend/shared/validators/buscarTarefas'
+import { AppError } from '@backend/shared/errors/app-error'
 
-export async function GET(req: Request) {
-  const url = new URL(req.url)
-  const params = Object.fromEntries(url.searchParams.entries())
-  const result = await buscarTarefasUsecase(params as any)
-  return new Response(JSON.stringify(result), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' }
-  })
+const safeJson = (data: unknown) =>
+  JSON.parse(
+    JSON.stringify(data, (_, value) =>
+      typeof value === 'bigint' ? value.toString() : value
+    )
+  )
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url)
+    const params = buscarTarefasSchema.parse(
+      Object.fromEntries(url.searchParams.entries())
+    )
+    const result = await buscarTarefasUsecase(params)
+    return NextResponse.json(safeJson(result))
+  } catch (error) {
+    console.error('GET /api/tarefas/buscar', error)
+    if (error instanceof ZodError || error instanceof AppError) {
+      return NextResponse.json({ message: error.message }, { status: 400 })
+    }
+    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 })
+  }
 }
+

--- a/src/app/api/tarefas/deletar/route.ts
+++ b/src/app/api/tarefas/deletar/route.ts
@@ -1,17 +1,27 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
+import { ZodError } from 'zod'
 import { deletarTarefaUsecase } from '@backend/usecases/tarefas/deletarTarefa.usecase'
+import { deletarTarefaSchema } from '@backend/shared/validators/deletarTarefa'
 import { AppError } from '@backend/shared/errors/app-error'
 
-export async function DELETE(request: NextRequest) {
-  const data = await request.json()
+const safeJson = (data: unknown) =>
+  JSON.parse(
+    JSON.stringify(data, (_, value) =>
+      typeof value === 'bigint' ? value.toString() : value
+    )
+  )
+
+export async function DELETE(request: Request) {
   try {
-    await deletarTarefaUsecase(data)
-    return NextResponse.json({ message: 'Tarefa deletada com sucesso' }, { status: 200 })
+    const body = deletarTarefaSchema.parse(await request.json())
+    await deletarTarefaUsecase(body)
+    return NextResponse.json(safeJson({ message: 'Tarefa deletada com sucesso' }))
   } catch (error) {
-    if (error instanceof AppError) {
+    console.error('DELETE /api/tarefas/deletar', error)
+    if (error instanceof ZodError || error instanceof AppError) {
       return NextResponse.json({ message: error.message }, { status: 400 })
     }
-    console.log(error)
     return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 })
   }
 }
+

--- a/src/app/api/tarefas/editar/route.ts
+++ b/src/app/api/tarefas/editar/route.ts
@@ -1,17 +1,27 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
+import { ZodError } from 'zod'
 import { editarTarefaUsecase } from '@backend/usecases/tarefas/editarTarefa.usecase'
+import { editarTarefaSchema } from '@backend/shared/validators/editarTarefa'
 import { AppError } from '@backend/shared/errors/app-error'
 
-export async function PUT(request: NextRequest) {
-  const data = await request.json()
+const safeJson = (data: unknown) =>
+  JSON.parse(
+    JSON.stringify(data, (_, value) =>
+      typeof value === 'bigint' ? value.toString() : value
+    )
+  )
+
+export async function PUT(request: Request) {
   try {
-    const tarefa = await editarTarefaUsecase(data)
-    return NextResponse.json(tarefa, { status: 200 })
+    const body = editarTarefaSchema.parse(await request.json())
+    const tarefa = await editarTarefaUsecase(body)
+    return NextResponse.json(safeJson(tarefa))
   } catch (error) {
-    if (error instanceof AppError) {
+    console.error('PUT /api/tarefas/editar', error)
+    if (error instanceof ZodError || error instanceof AppError) {
       return NextResponse.json({ message: error.message }, { status: 400 })
     }
-    console.log(error)
     return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 })
   }
 }
+

--- a/src/app/api/tipos/buscar/route.ts
+++ b/src/app/api/tipos/buscar/route.ts
@@ -1,11 +1,30 @@
+import { NextResponse } from 'next/server'
+import { ZodError } from 'zod'
 import { buscarTiposUsecase } from '@backend/usecases/tipos/buscarTipos.usecase'
+import { buscarTiposSchema } from '@backend/shared/validators/buscarTipos'
+import { AppError } from '@backend/shared/errors/app-error'
 
-export async function GET(req: Request) {
-  const url = new URL(req.url)
-  const params = Object.fromEntries(url.searchParams.entries())
-  const result = await buscarTiposUsecase(params as any)
-  return new Response(JSON.stringify(result), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' }
-  })
+const safeJson = (data: unknown) =>
+  JSON.parse(
+    JSON.stringify(data, (_, value) =>
+      typeof value === 'bigint' ? value.toString() : value
+    )
+  )
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url)
+    const params = buscarTiposSchema.parse(
+      Object.fromEntries(url.searchParams.entries())
+    )
+    const result = await buscarTiposUsecase(params)
+    return NextResponse.json(safeJson(result))
+  } catch (error) {
+    console.error('GET /api/tipos/buscar', error)
+    if (error instanceof ZodError || error instanceof AppError) {
+      return NextResponse.json({ message: error.message }, { status: 400 })
+    }
+    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 })
+  }
 }
+

--- a/src/backend/tests/buscarColaboradores.e2e.spec.ts
+++ b/src/backend/tests/buscarColaboradores.e2e.spec.ts
@@ -16,9 +16,10 @@ describe('GET /api/colaboradores/buscar', () => {
     const res = await GET(req as any)
     expect(res.status).toBe(200)
     expect(buscarColaboradoresUsecase).toHaveBeenCalledWith({
-      page: '1',
-      perPage: '10',
+      page: 1,
+      perPage: 10,
       nome: 'joao'
     })
   })
 })
+

--- a/src/backend/tests/buscarTarefas.e2e.spec.ts
+++ b/src/backend/tests/buscarTarefas.e2e.spec.ts
@@ -11,14 +11,15 @@ import { buscarTarefasUsecase } from '@backend/usecases/tarefas/buscarTarefas.us
 
 describe('GET /api/tarefas/buscar', () => {
   it('retorna 200 e chama usecase', async () => {
-    const url = new URL('http://localhost/api/tarefas/buscar?statusId=1&page=1&perPage=10')
+    const url = new URL('http://localhost/api/tarefas/buscar?statusId=00000000-0000-0000-0000-000000000000&page=1&perPage=10')
     const req = new Request(url.toString())
     const res = await GET(req as any)
     expect(res.status).toBe(200)
     expect(buscarTarefasUsecase).toHaveBeenCalledWith({
-      statusId: '1',
-      page: '1',
-      perPage: '10'
+      statusId: '00000000-0000-0000-0000-000000000000',
+      page: 1,
+      perPage: 10
     })
   })
 })
+

--- a/src/backend/tests/buscarTipos.e2e.spec.ts
+++ b/src/backend/tests/buscarTipos.e2e.spec.ts
@@ -17,8 +17,9 @@ describe('GET /api/tipos/buscar', () => {
     expect(res.status).toBe(200)
     expect(buscarTiposUsecase).toHaveBeenCalledWith({
       nome: 'abc',
-      page: '1',
-      perPage: '10'
+      page: 1,
+      perPage: 10
     })
   })
 })
+

--- a/src/backend/tests/criarTarefa.e2e.spec.ts
+++ b/src/backend/tests/criarTarefa.e2e.spec.ts
@@ -7,12 +7,25 @@ vi.mock('@backend/usecases/tarefas/criarTarefa.usecase', () => {
 
 describe('POST /api/tarefas/criar', () => {
   it('retorna 201', async () => {
+    const body = {
+      titulo: 't',
+      descricao: 'd',
+      prioridade: 'alta',
+      associacaoId: '00000000-0000-0000-0000-000000000000',
+      criadorId: '00000000-0000-0000-0000-000000000000',
+      responsavelId: '00000000-0000-0000-0000-000000000000',
+      statusId: null,
+      tipoId: '00000000-0000-0000-0000-000000000000',
+      data_inicio: new Date().toISOString(),
+      data_fim: new Date().toISOString()
+    }
     const req = new Request('http://localhost/api/tarefas/criar', {
       method: 'POST',
-      body: JSON.stringify({ titulo: 't' }),
+      body: JSON.stringify(body),
       headers: { 'Content-Type': 'application/json' }
     })
     const res = await POST(req as any)
     expect(res.status).toBe(201)
   })
 })
+


### PR DESCRIPTION
## Summary
- standardize API routes to always return JSON with NextResponse
- validate and coerce request data using zod schemas
- add error logging and BigInt-safe serialization

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae62483c6c832b9b7a46245a9cab0f