### PR TITLE
refactor: replace any with proper types

### DIFF
--- a/src/app/(protected)/dashboard/associacoes/[id]/page.tsx
+++ b/src/app/(protected)/dashboard/associacoes/[id]/page.tsx
@@ -1,4 +1,8 @@
-export default function AssociacaoPage({ params }: any) {
+interface AssociacaoPageProps {
+  params: { id: string }
+}
+
+export default function AssociacaoPage({ params }: AssociacaoPageProps) {
   return (
     <div className="p-6">
       <h1 className="text-2xl font-semibold mb-2">Detalhes da Associação</h1>

--- a/src/app/(protected)/dashboard/tarefas/components/add-task-dialog.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/add-task-dialog.tsx
@@ -47,6 +47,22 @@ const formSchema = z.object({
   dataFim: z.date().optional(),
 })
 
+interface Colaborador {
+  id: string
+  nome: string
+  funcao: string
+}
+
+interface Associacao {
+  id: string
+  nome: string
+}
+
+interface Tipo {
+  id: string
+  nome: string
+}
+
 export function AddTaskDialog() {
   const [open, setOpen] = useState(false)
   const [usuarios, setUsuarios] = useState<{ value: string; label: string }[]>([])
@@ -72,29 +88,29 @@ export function AddTaskDialog() {
   })
 
   useEffect(() => {
-    async function fetchJson(url: string) {
+    async function fetchJson<T>(url: string): Promise<T> {
       const res = await fetch(url)
       if (!res.ok) {
         const message = await res.text()
         throw new Error(message || 'Erro ao buscar dados')
       }
-      return res.json()
+      return res.json() as Promise<T>
     }
 
     async function fetchOptions() {
       try {
         const [usuariosRes, associacoesRes, tiposRes] = await Promise.all([
-          fetchJson('/api/colaboradores/buscar?page=1&perPage=100'),
-          fetchJson('/api/associacoes/buscar?page=1&perPage=100'),
-          fetchJson('/api/tipos/buscar?page=1&perPage=100'),
+          fetchJson<{ colaboradores: Colaborador[] }>('/api/colaboradores/buscar?page=1&perPage=100'),
+          fetchJson<{ associacoes: Associacao[] }>('/api/associacoes/buscar?page=1&perPage=100'),
+          fetchJson<{ tipos: Tipo[] }>('/api/tipos/buscar?page=1&perPage=100'),
         ])
 
-        const usuariosOptions = usuariosRes.colaboradores.map((u: any) => ({
+        const usuariosOptions = usuariosRes.colaboradores.map((u) => ({
           value: u.id,
           label: `${u.nome} - ${u.funcao.toLowerCase()}`,
         }))
-        const associacoesOptions = associacoesRes.associacoes.map((a: any) => ({ value: a.id, label: a.nome }))
-        const tiposOptions = tiposRes.tipos.map((t: any) => ({ value: t.id, label: t.nome }))
+        const associacoesOptions = associacoesRes.associacoes.map((a) => ({ value: a.id, label: a.nome }))
+        const tiposOptions = tiposRes.tipos.map((t) => ({ value: t.id, label: t.nome }))
 
         setUsuarios(usuariosOptions)
         setAssociacoes(associacoesOptions)
@@ -103,7 +119,7 @@ export function AddTaskDialog() {
         if (usuariosOptions[0]) form.setValue('responsavel', usuariosOptions[0].value)
         if (associacoesOptions[0]) form.setValue('associacao', associacoesOptions[0].value)
         if (tiposOptions[0]) form.setValue('tipo', tiposOptions[0].value)
-      } catch (err) {
+      } catch (err: unknown) {
         console.error('Erro ao buscar dados', err)
         setError('Erro ao carregar opções')
       }
@@ -151,7 +167,7 @@ export function AddTaskDialog() {
       setOpen(false)
       form.reset()
       router.refresh()
-    } catch (e) {
+    } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Erro ao criar tarefa')
     } finally {
       setIsLoading(false)

--- a/src/app/(protected)/dashboard/tarefas/components/data-table-row-actions.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/data-table-row-actions.tsx
@@ -40,7 +40,7 @@ interface DataTableRowActionsProps<TData> {
 }
 
 export function DataTableRowActions<TData>({ row }: DataTableRowActionsProps<TData>) {
-  const task = row.original as any
+  const task = row.original as Task
   const router = useRouter()
   const notify = useNotification()
 
@@ -59,7 +59,7 @@ export function DataTableRowActions<TData>({ row }: DataTableRowActionsProps<TDa
       } else {
         notify({ type: "error", title: "Tarefa", message: "Falha ao excluir tarefa" })
       }
-    } catch (error) {
+    } catch (error: unknown) {
       notify({ type: "error", title: "Tarefa", message: "Erro ao excluir tarefa" })
     }
   }

--- a/src/app/(protected)/dashboard/tarefas/page.tsx
+++ b/src/app/(protected)/dashboard/tarefas/page.tsx
@@ -24,35 +24,53 @@ async function fetchJSON<T>(url: string) {
 
   try {
     return JSON.parse(text) as T
-  } catch (e) {
+  } catch (e: unknown) {
     console.error(`[fetchJSON] ${url} -> Invalid JSON; preview:`, text.slice(0, 200))
     throw e
   }
 }
 
 export default async function TarefasPage() {
-  let tarefas: any[] = []
-  let associacoes: any[] = []
+  interface TarefaApi {
+    id: string
+    createdat: string
+    titulo: string
+    descricao: string
+    status?: { nome: string } | null
+    prioridade?: string | null
+    data_fim?: string | null
+    responsavelid?: string | null
+    associacaoid?: string | null
+    tipoid?: string | null
+  }
+
+  interface AssociacaoApi {
+    id: string
+    nome: string
+  }
+
+  let tarefas: TarefaApi[] = []
+  let associacoes: AssociacaoApi[] = []
 
   try {
     // Use rotas relativas pra aproveitar sessão/cookies e evitar CORS
     const [tarefasData, associacoesData] = await Promise.all([
-      fetchJSON<{ tarefas?: any[] }>("/api/tarefas/buscar"),
-      fetchJSON<{ associacoes?: any[] }>("/api/associacoes/buscar?page=1&perPage=100"),
+      fetchJSON<{ tarefas?: TarefaApi[] }>("/api/tarefas/buscar"),
+      fetchJSON<{ associacoes?: AssociacaoApi[] }>("/api/associacoes/buscar?page=1&perPage=100"),
     ])
 
     tarefas = tarefasData?.tarefas ?? []
     associacoes = associacoesData?.associacoes ?? []
-  } catch (error) {
+  } catch (error: unknown) {
     console.error("Erro ao buscar dados de tarefas/associações:", error)
     // segue com arrays vazios pra não quebrar a página
   }
 
   const associacoesMap = Object.fromEntries(
-    (associacoes ?? []).map((a: any) => [a.id, a.nome])
+    (associacoes ?? []).map((a: AssociacaoApi) => [a.id, a.nome])
   )
 
-  const tasks: Task[] = (tarefas ?? []).map((t: any) => ({
+  const tasks: Task[] = (tarefas ?? []).map((t: TarefaApi) => ({
     id: t.id,
     createdAt: t.createdat,           // confira o nome exato que a API retorna (created_at vs createdat)
     title: t.titulo,

--- a/src/backend/repositories/associacoes/__tests__/buscarAssociacoes.repository.spec.ts
+++ b/src/backend/repositories/associacoes/__tests__/buscarAssociacoes.repository.spec.ts
@@ -11,10 +11,11 @@ vi.mock('@backend/prisma/client', () => ({
 
 import { prisma } from '@backend/prisma/client'
 import { buscarAssociacoes } from '../buscarAssociacoes.repository'
+import { BuscarAssociacoesInput } from '@backend/shared/validators/buscarAssociacoes'
 
 describe('buscarAssociacoes.repository', () => {
   it('chama prisma com filtros e paginacao', async () => {
-    await buscarAssociacoes({ page: 2, perPage: 5, nome: 'test', cidade: 'city', estado: 'SP' } as any)
+    await buscarAssociacoes({ page: 2, perPage: 5, nome: 'test', cidade: 'city', estado: 'SP' } as unknown as BuscarAssociacoesInput)
     expect(prisma.associacao.findMany).toHaveBeenCalledWith({
       where: {
         nome: { contains: 'test', mode: 'insensitive' },

--- a/src/backend/repositories/associacoes/buscarAssociacoes.repository.ts
+++ b/src/backend/repositories/associacoes/buscarAssociacoes.repository.ts
@@ -1,8 +1,9 @@
 import { prisma } from '@backend/prisma/client'
 import { BuscarAssociacoesInput } from '@backend/shared/validators/buscarAssociacoes'
+import { Prisma } from '@prisma/client'
 
 export async function buscarAssociacoes({ page, perPage, nome, cidade, estado }: BuscarAssociacoesInput) {
-  const where: any = {}
+  const where: Prisma.AssociacaoWhereInput = {}
   if (nome) {
     where.nome = { contains: nome, mode: 'insensitive' }
   }

--- a/src/backend/repositories/colaboradores/__tests__/buscarColaboradores.repository.spec.ts
+++ b/src/backend/repositories/colaboradores/__tests__/buscarColaboradores.repository.spec.ts
@@ -11,10 +11,11 @@ vi.mock('@backend/prisma/client', () => ({
 
 import { prisma } from '@backend/prisma/client'
 import { buscarColaboradores } from '../buscarColaboradores.repository'
+import { BuscarColaboradoresInput } from '@backend/shared/validators/buscarColaboradores'
 
 describe('buscarColaboradores.repository', () => {
   it('chama prisma com filtros e paginacao', async () => {
-    await buscarColaboradores({ page: 2, perPage: 5, nome: 'test' } as any)
+    await buscarColaboradores({ page: 2, perPage: 5, nome: 'test' } as unknown as BuscarColaboradoresInput)
     expect(prisma.usuario.findMany).toHaveBeenCalledWith({
       where: { funcao: { in: ['COLABORADOR', 'ADM'] }, nome: { contains: 'test', mode: 'insensitive' } },
       select: { id: true, nome: true, funcao: true },

--- a/src/backend/repositories/colaboradores/buscarColaboradores.repository.ts
+++ b/src/backend/repositories/colaboradores/buscarColaboradores.repository.ts
@@ -1,8 +1,9 @@
 import { prisma } from '@backend/prisma/client'
 import { BuscarColaboradoresInput } from '@backend/shared/validators/buscarColaboradores'
+import { Prisma } from '@prisma/client'
 
 export async function buscarColaboradores({ page, perPage, nome }: BuscarColaboradoresInput) {
-  const where: any = { funcao: { in: ['COLABORADOR', 'ADM'] } }
+  const where: Prisma.UsuarioWhereInput = { funcao: { in: ['COLABORADOR', 'ADM'] } }
   if (nome) {
     where.nome = { contains: nome, mode: 'insensitive' }
   }

--- a/src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts
@@ -11,10 +11,11 @@ vi.mock('@backend/prisma/client', () => ({
 
 import { prisma } from '@backend/prisma/client'
 import { buscarTarefas } from '../buscarTarefas.repository'
+import { BuscarTarefasInput } from '@backend/shared/validators/buscarTarefas'
 
 describe('buscarTarefas.repository', () => {
   it('chama prisma com filtros e paginacao', async () => {
-    await buscarTarefas({ page: 2, perPage: 5, statusId: '1', titulo: 'test', prioridade: 'alta' } as any)
+    await buscarTarefas({ page: 2, perPage: 5, statusId: '1', titulo: 'test', prioridade: 'alta' } as unknown as BuscarTarefasInput)
     expect(prisma.tarefa.findMany).toHaveBeenCalledWith({
       where: { statusid: '1', prioridade: 'alta', titulo: { contains: 'test', mode: 'insensitive' } },
       skip: 5,

--- a/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { criarTarefa } from '../criarTarefa.repository'
 import { prisma } from '@backend/prisma/client'
 import { AppError } from '@backend/shared/errors/app-error'
+import { TarefaInput } from '@backend/shared/validators/tarefa'
 
 vi.mock('@backend/prisma/client', () => {
   return {
@@ -13,7 +14,7 @@ vi.mock('@backend/prisma/client', () => {
 })
 
 describe('criarTarefa.repository', () => {
-  const data: any = {
+  const data: TarefaInput = {
     titulo: 't',
     descricao: 'd',
     prioridade: 'p',
@@ -27,8 +28,8 @@ describe('criarTarefa.repository', () => {
   }
 
   it('insere tarefa com prisma', async () => {
-    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as any)
-    vi.mocked(prisma.tarefa.create).mockResolvedValue({ id: '1' } as any)
+    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as unknown)
+    vi.mocked(prisma.tarefa.create).mockResolvedValue({ id: '1' } as unknown)
     const result = await criarTarefa(data)
     expect(prisma.tarefa.create).toHaveBeenCalledWith({
       data: {
@@ -54,16 +55,16 @@ describe('criarTarefa.repository', () => {
   })
 
   it('lança AppError quando prisma retorna P2003 de responsavelid', async () => {
-    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as any)
+    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as unknown)
     const prismaError = { code: 'P2003', meta: { field_name: 'tarefa_responsavelid_fkey' } }
-    vi.mocked(prisma.tarefa.create).mockRejectedValue(prismaError as any)
+    vi.mocked(prisma.tarefa.create).mockRejectedValue(prismaError as unknown)
     await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)
   })
 
   it('lança AppError quando prisma retorna P2003 de criadorid', async () => {
-    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as any)
+    vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as unknown)
     const prismaError = { code: 'P2003', meta: { field_name: 'tarefa_criadorid_fkey' } }
-    vi.mocked(prisma.tarefa.create).mockRejectedValue(prismaError as any)
+    vi.mocked(prisma.tarefa.create).mockRejectedValue(prismaError as unknown)
     await expect(criarTarefa(data)).rejects.toBeInstanceOf(AppError)
   })
 })

--- a/src/backend/repositories/tarefas/__tests__/deletarTarefa.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/deletarTarefa.repository.spec.ts
@@ -11,7 +11,7 @@ vi.mock('@backend/prisma/client', () => ({
 
 describe('deletarTarefa.repository', () => {
   it('deleta tarefa pelo id', async () => {
-    vi.mocked(prisma.tarefa.delete).mockResolvedValue({ id: '1' } as any)
+    vi.mocked(prisma.tarefa.delete).mockResolvedValue({ id: '1' } as unknown)
     const result = await deletarTarefa('1')
     expect(prisma.tarefa.delete).toHaveBeenCalledWith({ where: { id: '1' } })
     expect(result).toEqual({ id: '1' })
@@ -19,7 +19,7 @@ describe('deletarTarefa.repository', () => {
 
   it('lança AppError quando tarefa não existe', async () => {
     const error = { code: 'P2025' }
-    vi.mocked(prisma.tarefa.delete).mockRejectedValue(error as any)
+    vi.mocked(prisma.tarefa.delete).mockRejectedValue(error as unknown)
     await expect(deletarTarefa('1')).rejects.toBeInstanceOf(AppError)
   })
 })

--- a/src/backend/repositories/tarefas/buscarTarefas.repository.ts
+++ b/src/backend/repositories/tarefas/buscarTarefas.repository.ts
@@ -1,8 +1,9 @@
 import { prisma } from '@backend/prisma/client'
 import { BuscarTarefasInput } from '@backend/shared/validators/buscarTarefas'
+import { Prisma } from '@prisma/client'
 
 export async function buscarTarefas({ page, perPage, titulo, statusId, prioridade }: BuscarTarefasInput) {
-  const where: any = {}
+  const where: Prisma.TarefaWhereInput = {}
   if (titulo) {
     where.titulo = { contains: titulo, mode: 'insensitive' }
   }

--- a/src/backend/repositories/tarefas/deletarTarefa.repository.ts
+++ b/src/backend/repositories/tarefas/deletarTarefa.repository.ts
@@ -1,11 +1,12 @@
 import { prisma } from '@backend/prisma/client'
 import { AppError } from '@backend/shared/errors/app-error'
+import { Prisma } from '@prisma/client'
 
 export async function deletarTarefa(id: string) {
   try {
     return await prisma.tarefa.delete({ where: { id } })
-  } catch (error: any) {
-    if (error?.code === 'P2025') {
+  } catch (error: unknown) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
       throw new AppError('Tarefa não encontrada')
     }
     throw error

--- a/src/backend/repositories/tarefas/editarTarefa.repository.ts
+++ b/src/backend/repositories/tarefas/editarTarefa.repository.ts
@@ -30,7 +30,7 @@ export async function editarTarefa(data: EditarTarefaInput) {
         ...(data.data_fim && { data_fim: data.data_fim })
       }
     })
-  } catch (error: any) {
+  } catch (error: unknown) {
     if (error instanceof AppError) {
       throw error
     }

--- a/src/backend/repositories/tipos/__tests__/buscarTipos.repository.spec.ts
+++ b/src/backend/repositories/tipos/__tests__/buscarTipos.repository.spec.ts
@@ -11,10 +11,11 @@ vi.mock('@backend/prisma/client', () => ({
 
 import { prisma } from '@backend/prisma/client'
 import { buscarTipos } from '../buscarTipos.repository'
+import { BuscarTiposInput } from '@backend/shared/validators/buscarTipos'
 
 describe('buscarTipos.repository', () => {
   it('chama prisma com filtros e paginacao', async () => {
-    await buscarTipos({ page: 2, perPage: 5, nome: 'test' } as any)
+    await buscarTipos({ page: 2, perPage: 5, nome: 'test' } as unknown as BuscarTiposInput)
     expect(prisma.tipo.findMany).toHaveBeenCalledWith({
       where: { nome: { contains: 'test', mode: 'insensitive' } },
       skip: 5,

--- a/src/backend/repositories/tipos/buscarTipos.repository.ts
+++ b/src/backend/repositories/tipos/buscarTipos.repository.ts
@@ -1,8 +1,9 @@
 import { prisma } from '@backend/prisma/client'
 import { BuscarTiposInput } from '@backend/shared/validators/buscarTipos'
+import { Prisma } from '@prisma/client'
 
 export async function buscarTipos({ page, perPage, nome }: BuscarTiposInput) {
-  const where: any = {}
+  const where: Prisma.TipoWhereInput = {}
   if (nome) {
     where.nome = { contains: nome, mode: 'insensitive' }
   }

--- a/src/backend/tests/buscarColaboradores.e2e.spec.ts
+++ b/src/backend/tests/buscarColaboradores.e2e.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { GET } from '../../app/api/colaboradores/buscar/route'
+import { NextRequest } from 'next/server'
 
 vi.mock('@backend/usecases/colaboradores/buscarColaboradores.usecase', () => {
   return {
@@ -13,7 +14,7 @@ describe('GET /api/colaboradores/buscar', () => {
   it('retorna 200 e chama usecase', async () => {
     const url = new URL('http://localhost/api/colaboradores/buscar?page=1&perPage=10&nome=joao')
     const req = new Request(url.toString())
-    const res = await GET(req as any)
+    const res = await GET(req as unknown as NextRequest)
     expect(res.status).toBe(200)
     expect(buscarColaboradoresUsecase).toHaveBeenCalledWith({
       page: 1,

--- a/src/backend/tests/buscarTarefas.e2e.spec.ts
+++ b/src/backend/tests/buscarTarefas.e2e.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { GET } from '../../app/api/tarefas/buscar/route'
+import { NextRequest } from 'next/server'
 
 vi.mock('@backend/usecases/tarefas/buscarTarefas.usecase', () => {
   return {
@@ -13,7 +14,7 @@ describe('GET /api/tarefas/buscar', () => {
   it('retorna 200 e chama usecase', async () => {
     const url = new URL('http://localhost/api/tarefas/buscar?statusId=00000000-0000-0000-0000-000000000000&page=1&perPage=10')
     const req = new Request(url.toString())
-    const res = await GET(req as any)
+    const res = await GET(req as unknown as NextRequest)
     expect(res.status).toBe(200)
     expect(buscarTarefasUsecase).toHaveBeenCalledWith({
       statusId: '00000000-0000-0000-0000-000000000000',

--- a/src/backend/tests/buscarTipos.e2e.spec.ts
+++ b/src/backend/tests/buscarTipos.e2e.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { GET } from '../../app/api/tipos/buscar/route'
+import { NextRequest } from 'next/server'
 
 vi.mock('@backend/usecases/tipos/buscarTipos.usecase', () => {
   return {
@@ -13,7 +14,7 @@ describe('GET /api/tipos/buscar', () => {
   it('retorna 200 e chama usecase', async () => {
     const url = new URL('http://localhost/api/tipos/buscar?nome=abc&page=1&perPage=10')
     const req = new Request(url.toString())
-    const res = await GET(req as any)
+    const res = await GET(req as unknown as NextRequest)
     expect(res.status).toBe(200)
     expect(buscarTiposUsecase).toHaveBeenCalledWith({
       nome: 'abc',

--- a/src/backend/tests/criarTarefa.e2e.spec.ts
+++ b/src/backend/tests/criarTarefa.e2e.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { POST } from '../../app/api/tarefas/criar/route'
+import { NextRequest } from 'next/server'
 
 vi.mock('@backend/usecases/tarefas/criarTarefa.usecase', () => {
   return { criarTarefaUsecase: vi.fn().mockResolvedValue({ id: '1' }) }
@@ -24,7 +25,7 @@ describe('POST /api/tarefas/criar', () => {
       body: JSON.stringify(body),
       headers: { 'Content-Type': 'application/json' }
     })
-    const res = await POST(req as any)
+    const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(201)
   })
 })

--- a/src/backend/usecases/associacoes/__tests__/buscarAssociacoes.usecase.spec.ts
+++ b/src/backend/usecases/associacoes/__tests__/buscarAssociacoes.usecase.spec.ts
@@ -6,6 +6,7 @@ vi.mock('@backend/repositories/associacoes/buscarAssociacoes.repository', () => 
 
 import { buscarAssociacoes } from '@backend/repositories/associacoes/buscarAssociacoes.repository'
 import { buscarAssociacoesUsecase } from '../buscarAssociacoes.usecase'
+import { BuscarAssociacoesInput } from '@backend/shared/validators/buscarAssociacoes'
 
 describe('buscarAssociacoesUsecase', () => {
   it('valida dados e chama repositorio', async () => {
@@ -17,7 +18,7 @@ describe('buscarAssociacoesUsecase', () => {
       nome: 'abc',
       cidade: 'xyz',
       estado: 'SP'
-    } as any)
+    } as unknown as BuscarAssociacoesInput)
     expect(spy).toHaveBeenCalledWith({
       page: 2,
       perPage: 5,

--- a/src/backend/usecases/colaboradores/__tests__/buscarColaboradores.usecase.spec.ts
+++ b/src/backend/usecases/colaboradores/__tests__/buscarColaboradores.usecase.spec.ts
@@ -6,12 +6,13 @@ vi.mock('@backend/repositories/colaboradores/buscarColaboradores.repository', ()
 
 import { buscarColaboradores } from '@backend/repositories/colaboradores/buscarColaboradores.repository'
 import { buscarColaboradoresUsecase } from '../buscarColaboradores.usecase'
+import { BuscarColaboradoresInput } from '@backend/shared/validators/buscarColaboradores'
 
 describe('buscarColaboradoresUsecase', () => {
   it('valida dados e chama repositorio', async () => {
     const spy = vi.mocked(buscarColaboradores)
     spy.mockResolvedValue({ colaboradores: [], total: 0 })
-    await buscarColaboradoresUsecase({ page: '2', perPage: '5', nome: 'abc' } as any)
+    await buscarColaboradoresUsecase({ page: '2', perPage: '5', nome: 'abc' } as unknown as BuscarColaboradoresInput)
     expect(spy).toHaveBeenCalledWith({ page: 2, perPage: 5, nome: 'abc' })
   })
 })

--- a/src/backend/usecases/tarefas/__tests__/buscarTarefas.usecase.spec.ts
+++ b/src/backend/usecases/tarefas/__tests__/buscarTarefas.usecase.spec.ts
@@ -6,6 +6,7 @@ vi.mock('@backend/repositories/tarefas/buscarTarefas.repository', () => ({
 
 import { buscarTarefas } from '@backend/repositories/tarefas/buscarTarefas.repository'
 import { buscarTarefasUsecase } from '../buscarTarefas.usecase'
+import { BuscarTarefasInput } from '@backend/shared/validators/buscarTarefas'
 
 describe('buscarTarefasUsecase', () => {
   it('valida dados e chama repositorio', async () => {
@@ -16,7 +17,7 @@ describe('buscarTarefasUsecase', () => {
       perPage: '5',
       statusId: '00000000-0000-0000-0000-000000000000',
       titulo: 'abc'
-    } as any)
+    } as unknown as BuscarTarefasInput)
     expect(spy).toHaveBeenCalledWith({
       page: 2,
       perPage: 5,

--- a/src/backend/usecases/tarefas/__tests__/criarTarefa.usecase.spec.ts
+++ b/src/backend/usecases/tarefas/__tests__/criarTarefa.usecase.spec.ts
@@ -10,7 +10,7 @@ import { criarTarefaUsecase } from '../criarTarefa.usecase'
 describe('criarTarefaUsecase', () => {
   it('valida dados e chama repositorio', async () => {
     const spy = vi.mocked(criarTarefa)
-    spy.mockResolvedValue({ id: '1' } as any)
+    spy.mockResolvedValue({ id: '1' } as unknown)
     await criarTarefaUsecase({
       titulo: 't',
       descricao: 'd',

--- a/src/backend/usecases/tarefas/__tests__/deletarTarefa.usecase.spec.ts
+++ b/src/backend/usecases/tarefas/__tests__/deletarTarefa.usecase.spec.ts
@@ -10,7 +10,7 @@ import { deletarTarefaUsecase } from '../deletarTarefa.usecase'
 describe('deletarTarefaUsecase', () => {
   it('valida dados e chama repositorio', async () => {
     const spy = vi.mocked(deletarTarefa)
-    spy.mockResolvedValue({} as any)
+    spy.mockResolvedValue({} as unknown)
     await deletarTarefaUsecase({ id: '00000000-0000-0000-0000-000000000000' })
     expect(spy).toHaveBeenCalledWith('00000000-0000-0000-0000-000000000000')
   })

--- a/src/backend/usecases/tipos/__tests__/buscarTipos.usecase.spec.ts
+++ b/src/backend/usecases/tipos/__tests__/buscarTipos.usecase.spec.ts
@@ -6,12 +6,13 @@ vi.mock('@backend/repositories/tipos/buscarTipos.repository', () => ({
 
 import { buscarTipos } from '@backend/repositories/tipos/buscarTipos.repository'
 import { buscarTiposUsecase } from '../buscarTipos.usecase'
+import { BuscarTiposInput } from '@backend/shared/validators/buscarTipos'
 
 describe('buscarTiposUsecase', () => {
   it('valida dados e chama repositorio', async () => {
     const spy = vi.mocked(buscarTipos)
     spy.mockResolvedValue({ tipos: [], total: 0 })
-    await buscarTiposUsecase({ page: '2', perPage: '5', nome: 'abc' } as any)
+    await buscarTiposUsecase({ page: '2', perPage: '5', nome: 'abc' } as unknown as BuscarTiposInput)
     expect(spy).toHaveBeenCalledWith({ page: 2, perPage: 5, nome: 'abc' })
   })
 })


### PR DESCRIPTION
## Summary
- add dedicated props interface for Association page
- strongly type Prisma filters and error handling
- define API response types for task dialogs and remove `any`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module '.prisma/client/default')*


------
https://chatgpt.com/codex/tasks/task_e_68ae739782d8832bb7a3f227eb34651a