### PR TITLE
refactor: replace type aliases with interfaces

### DIFF
--- a/src/app/(protected)/dashboard/tarefas/components/columns.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/columns.tsx
@@ -7,7 +7,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 
 import { labels, priorities, statuses } from "./data"
 
-export type Task = {
+export interface Task {
   id: string
   createdAt: string
   title: string

--- a/src/app/(protected)/dashboard/tarefas/components/data-table-row-actions.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/data-table-row-actions.tsx
@@ -20,7 +20,7 @@ import {
 
 import { labels } from "./data"
 import { EditTaskDialog } from "./edit-task-dialog"
-import { Task } from "./columns"
+import type { Task } from "./columns"
 import { useRouter } from "next/navigation"
 import {
   AlertDialog,
@@ -40,7 +40,7 @@ interface DataTableRowActionsProps<TData> {
 }
 
 export function DataTableRowActions<TData>({ row }: DataTableRowActionsProps<TData>) {
-  const task = row.original as any
+  const task = row.original as Task
   const router = useRouter()
   const notify = useNotification()
 

--- a/src/app/(protected)/dashboard/tarefas/components/edit-task-dialog.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/edit-task-dialog.tsx
@@ -36,7 +36,7 @@ import {
   FormControl,
   FormMessage,
 } from '@/components/ui/form'
-import { Task } from './columns'
+import type { Task } from './columns'
 import {
   AlertDialog,
   AlertDialogAction,

--- a/src/app/(protected)/dashboard/tarefas/page.tsx
+++ b/src/app/(protected)/dashboard/tarefas/page.tsx
@@ -1,5 +1,5 @@
 // app/(private)/tarefas/page.tsx
-import { columns, Task } from "./components/columns"
+import { columns, type Task } from "./components/columns"
 import { DataTable } from "./components/data-table"
 
 // Helper robusto para JSON

--- a/src/components/notification-provider.tsx
+++ b/src/components/notification-provider.tsx
@@ -4,13 +4,15 @@ import { createContext, useContext, useState, useCallback, ReactNode } from "rea
 import { CheckCircle2, AlertCircle } from "lucide-react"
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert"
 
-type Notification = {
+interface Notification {
   type: "success" | "error"
   title?: string
   message: string
 }
 
-type NotifyFn = (n: Notification) => void
+interface NotifyFn {
+  (n: Notification): void
+}
 
 const NotificationContext = createContext<NotifyFn | null>(null)
 

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -17,10 +17,10 @@ import { Label } from "@/components/ui/label"
 
 const Form = FormProvider
 
-type FormFieldContextValue<
+interface FormFieldContextValue<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
-> = {
+> {
   name: TName
 }
 
@@ -64,7 +64,7 @@ const useFormField = () => {
   }
 }
 
-type FormItemContextValue = {
+interface FormItemContextValue {
   id: string
 }
 

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -32,7 +32,7 @@ const SIDEBAR_WIDTH_MOBILE = "18rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
-type SidebarContextProps = {
+interface SidebarContextProps {
   state: "expanded" | "collapsed"
   open: boolean
   setOpen: (open: boolean) => void


### PR DESCRIPTION
## Summary
- convert Task alias to interface and fix consuming imports
- use interfaces for Notification, SidebarContext, and Form contexts
- adjust callback type to named function signature

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae739b18ac832bba7ee7eca2cd4b37