### PR TITLE
test: centralize prisma mocking for unit tests

### DIFF
--- a/prisma/__mocks__/client.ts
+++ b/prisma/__mocks__/client.ts
@@ -1,0 +1,40 @@
+import { vi } from 'vitest'
+
+class PrismaClientKnownRequestError extends Error {
+  code: string
+  meta?: unknown
+  constructor({ code, meta }: { code: string; meta?: unknown }) {
+    super()
+    this.code = code
+    this.meta = meta
+  }
+}
+
+export const Prisma = { PrismaClientKnownRequestError }
+
+export class PrismaClient {
+  tipo = {
+    findMany: vi.fn(),
+    count: vi.fn()
+  }
+
+  usuario = {
+    findMany: vi.fn(),
+    count: vi.fn(),
+    findUnique: vi.fn()
+  }
+
+  tarefa = {
+    findMany: vi.fn(),
+    count: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn()
+  }
+
+  associacao = {
+    findMany: vi.fn(),
+    count: vi.fn()
+  }
+}
+
+export const prisma = new PrismaClient()

--- a/src/backend/repositories/associacoes/__tests__/buscarAssociacoes.repository.spec.ts
+++ b/src/backend/repositories/associacoes/__tests__/buscarAssociacoes.repository.spec.ts
@@ -1,32 +1,20 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 
-vi.mock('@prisma/client', () => {
-  class PrismaClientKnownRequestError extends Error {
-    code: string
-    meta?: unknown
-    constructor({ code, meta }: { code: string; meta?: unknown }) {
-      super()
-      this.code = code
-      this.meta = meta
-    }
-  }
-  return {
-    prisma: {
-      associacao: {
-        findMany: vi.fn().mockResolvedValue([]),
-        count: vi.fn().mockResolvedValue(0)
-      }
-    },
-    Prisma: { PrismaClientKnownRequestError }
-  }
-})
+vi.mock('@prisma/client')
 
 import { prisma } from '@prisma/client'
 import { buscarAssociacoes } from '@/backend/repositories/associacoes/buscarAssociacoes.repository'
 import { BuscarAssociacoesInput } from '@/backend/shared/validators/buscarAssociacoes'
 
 describe('buscarAssociacoes.repository', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('chama prisma com filtros e paginacao', async () => {
+    vi.mocked(prisma.associacao.findMany).mockResolvedValue([])
+    vi.mocked(prisma.associacao.count).mockResolvedValue(0)
+
     await buscarAssociacoes({ page: 2, perPage: 5, nome: 'test', cidade: 'city', estado: 'SP' } as unknown as BuscarAssociacoesInput)
     expect(prisma.associacao.findMany).toHaveBeenCalledWith({
       where: {

--- a/src/backend/repositories/colaboradores/__tests__/buscarColaboradores.repository.spec.ts
+++ b/src/backend/repositories/colaboradores/__tests__/buscarColaboradores.repository.spec.ts
@@ -1,32 +1,20 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 
-vi.mock('@prisma/client', () => {
-  class PrismaClientKnownRequestError extends Error {
-    code: string
-    meta?: unknown
-    constructor({ code, meta }: { code: string; meta?: unknown }) {
-      super()
-      this.code = code
-      this.meta = meta
-    }
-  }
-  return {
-    prisma: {
-      usuario: {
-        findMany: vi.fn().mockResolvedValue([]),
-        count: vi.fn().mockResolvedValue(0)
-      }
-    },
-    Prisma: { PrismaClientKnownRequestError }
-  }
-})
+vi.mock('@prisma/client')
 
 import { prisma } from '@prisma/client'
 import { buscarColaboradores } from '@/backend/repositories/colaboradores/buscarColaboradores.repository'
 import { BuscarColaboradoresInput } from '@/backend/shared/validators/buscarColaboradores'
 
 describe('buscarColaboradores.repository', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('chama prisma com filtros e paginacao', async () => {
+    vi.mocked(prisma.usuario.findMany).mockResolvedValue([])
+    vi.mocked(prisma.usuario.count).mockResolvedValue(0)
+
     await buscarColaboradores({ page: 2, perPage: 5, nome: 'test' } as unknown as BuscarColaboradoresInput)
     expect(prisma.usuario.findMany).toHaveBeenCalledWith({
       where: { funcao: { in: ['COLABORADOR', 'ADM'] }, nome: { contains: 'test', mode: 'insensitive' } },

--- a/src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts
@@ -1,32 +1,20 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 
-vi.mock('@prisma/client', () => {
-  class PrismaClientKnownRequestError extends Error {
-    code: string
-    meta?: unknown
-    constructor({ code, meta }: { code: string; meta?: unknown }) {
-      super()
-      this.code = code
-      this.meta = meta
-    }
-  }
-  return {
-    prisma: {
-      tarefa: {
-        findMany: vi.fn().mockResolvedValue([]),
-        count: vi.fn().mockResolvedValue(0)
-      }
-    },
-    Prisma: { PrismaClientKnownRequestError }
-  }
-})
+vi.mock('@prisma/client')
 
 import { prisma } from '@prisma/client'
 import { buscarTarefas } from '@/backend/repositories/tarefas/buscarTarefas.repository'
 import { BuscarTarefasInput } from '@/backend/shared/validators/buscarTarefas'
 
 describe('buscarTarefas.repository', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('chama prisma com filtros e paginacao', async () => {
+    vi.mocked(prisma.tarefa.findMany).mockResolvedValue([])
+    vi.mocked(prisma.tarefa.count).mockResolvedValue(0)
+
     await buscarTarefas({ page: 2, perPage: 5, statusId: '1', titulo: 'test', prioridade: 'alta' } as unknown as BuscarTarefasInput)
     expect(prisma.tarefa.findMany).toHaveBeenCalledWith({
       where: { statusid: '1', prioridade: 'alta', titulo: { contains: 'test', mode: 'insensitive' } },

--- a/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/criarTarefa.repository.spec.ts
@@ -1,27 +1,10 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { criarTarefa } from '@/backend/repositories/tarefas/criarTarefa.repository'
 import { prisma, Prisma } from '@prisma/client'
 import { AppError } from '@/backend/shared/errors/app-error'
 import { TarefaInput } from '@/backend/shared/validators/tarefa'
 
-vi.mock('@prisma/client', () => {
-  class PrismaClientKnownRequestError extends Error {
-    code: string
-    meta?: unknown
-    constructor({ code, meta }: { code: string; meta?: unknown }) {
-      super()
-      this.code = code
-      this.meta = meta
-    }
-  }
-  return {
-    prisma: {
-      tarefa: { create: vi.fn() },
-      usuario: { findUnique: vi.fn() }
-    },
-    Prisma: { PrismaClientKnownRequestError }
-  }
-})
+vi.mock('@prisma/client')
 
 describe('criarTarefa.repository', () => {
   const data: TarefaInput = {
@@ -36,6 +19,10 @@ describe('criarTarefa.repository', () => {
     data_inicio: new Date('2024-01-01'),
     data_fim: new Date('2024-01-02'),
   }
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
 
   it('insere tarefa com prisma', async () => {
     vi.mocked(prisma.usuario.findUnique).mockResolvedValue({ id: 'responsavel' } as unknown)

--- a/src/backend/repositories/tarefas/__tests__/deletarTarefa.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/deletarTarefa.repository.spec.ts
@@ -1,27 +1,15 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { deletarTarefa } from '@/backend/repositories/tarefas/deletarTarefa.repository'
 import { prisma, Prisma } from '@prisma/client'
 import { AppError } from '@/backend/shared/errors/app-error'
 
-vi.mock('@prisma/client', () => {
-  class PrismaClientKnownRequestError extends Error {
-    code: string
-    meta?: unknown
-    constructor({ code, meta }: { code: string; meta?: unknown }) {
-      super()
-      this.code = code
-      this.meta = meta
-    }
-  }
-  return {
-    prisma: {
-      tarefa: { delete: vi.fn() }
-    },
-    Prisma: { PrismaClientKnownRequestError }
-  }
-})
+vi.mock('@prisma/client')
 
 describe('deletarTarefa.repository', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('deleta tarefa pelo id', async () => {
     vi.mocked(prisma.tarefa.delete).mockResolvedValue({ id: '1' } as unknown)
     const result = await deletarTarefa('1')

--- a/src/backend/repositories/tipos/__tests__/buscarTipos.repository.spec.ts
+++ b/src/backend/repositories/tipos/__tests__/buscarTipos.repository.spec.ts
@@ -1,32 +1,20 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 
-vi.mock('@prisma/client', () => {
-  class PrismaClientKnownRequestError extends Error {
-    code: string
-    meta?: unknown
-    constructor({ code, meta }: { code: string; meta?: unknown }) {
-      super()
-      this.code = code
-      this.meta = meta
-    }
-  }
-  return {
-    prisma: {
-      tipo: {
-        findMany: vi.fn().mockResolvedValue([]),
-        count: vi.fn().mockResolvedValue(0)
-      }
-    },
-    Prisma: { PrismaClientKnownRequestError }
-  }
-})
+vi.mock('@prisma/client')
 
 import { prisma } from '@prisma/client'
 import { buscarTipos } from '@/backend/repositories/tipos/buscarTipos.repository'
 import { BuscarTiposInput } from '@/backend/shared/validators/buscarTipos'
 
 describe('buscarTipos.repository', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('chama prisma com filtros e paginacao', async () => {
+    vi.mocked(prisma.tipo.findMany).mockResolvedValue([])
+    vi.mocked(prisma.tipo.count).mockResolvedValue(0)
+
     await buscarTipos({ page: 2, perPage: 5, nome: 'test' } as unknown as BuscarTiposInput)
     expect(prisma.tipo.findMany).toHaveBeenCalledWith({
       where: { nome: { contains: 'test', mode: 'insensitive' } },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
       "@prisma/*": ["prisma/*"]
     }
   },
-  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx", "prisma/**/*.ts", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add Vitest-friendly Prisma client mock
- refactor repository tests to use shared Prisma mock
- include prisma directory in TypeScript config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae82c44f3c832b8aac75f5aa8c3970