### PR TITLE
test: add error cases for task routes

### DIFF
--- a/src/backend/tests/buscarTarefas.e2e.spec.ts
+++ b/src/backend/tests/buscarTarefas.e2e.spec.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createTestContext, TestContext } from './utils/testContext'
 import { randomUUID } from 'crypto'
+import * as buscarTarefasUsecaseModule from '@/backend/usecases/tarefas/buscarTarefas.usecase'
 
 let ctx: TestContext
 let userId: string
@@ -34,6 +35,8 @@ describe('GET /api/tarefas/buscar', () => {
   })
 
   afterEach(async () => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
     await ctx.close()
   })
 
@@ -42,5 +45,14 @@ describe('GET /api/tarefas/buscar', () => {
     expect(res.status).toBe(200)
     expect(res.body.tarefas).toHaveLength(1)
     expect(res.body.tarefas[0].titulo).toBe('t')
+  })
+
+  it('retorna 500 quando usecase falha', async () => {
+    vi.spyOn(buscarTarefasUsecaseModule, 'buscarTarefasUsecase').mockRejectedValue(
+      new Error('fail')
+    )
+    const res = await ctx.request.get(`/api/tarefas/buscar?statusId=${STATUS_ID}&page=1&perPage=10`)
+    expect(res.status).toBe(500)
+    expect(res.body.message).toBe('Internal Server Error')
   })
 })

--- a/src/backend/tests/criarTarefa.e2e.spec.ts
+++ b/src/backend/tests/criarTarefa.e2e.spec.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createTestContext, TestContext } from './utils/testContext'
 import { randomUUID } from 'crypto'
+import * as criarTarefaUsecaseModule from '@/backend/usecases/tarefas/criarTarefa.usecase'
 
 let ctx: TestContext
 let criadorId: string
@@ -17,6 +18,8 @@ describe('POST /api/tarefas/criar', () => {
   })
 
   afterEach(async () => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
     await ctx.close()
   })
 
@@ -39,5 +42,32 @@ describe('POST /api/tarefas/criar', () => {
     const tarefas = await ctx.prisma.tarefa.findMany()
     expect(tarefas).toHaveLength(1)
     expect(tarefas[0].titulo).toBe('t')
+  })
+
+  it('retorna 400 para payload inválido', async () => {
+    const res = await ctx.request.post('/api/tarefas/criar').send({})
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('message')
+  })
+
+  it('retorna 500 quando usecase falha', async () => {
+    vi.spyOn(criarTarefaUsecaseModule, 'criarTarefaUsecase').mockRejectedValue(
+      new Error('fail')
+    )
+    const body = {
+      titulo: 't',
+      descricao: 'd',
+      prioridade: 'alta',
+      associacaoId: '00000000-0000-0000-0000-000000000000',
+      criadorId: criadorId,
+      responsavelId: '00000000-0000-0000-0000-000000000000',
+      statusId: null,
+      tipoId: '00000000-0000-0000-0000-000000000000',
+      data_inicio: new Date().toISOString(),
+      data_fim: new Date().toISOString()
+    }
+    const res = await ctx.request.post('/api/tarefas/criar').send(body)
+    expect(res.status).toBe(500)
+    expect(res.body.message).toBe('Internal Server Error')
   })
 })


### PR DESCRIPTION
## Summary
- add invalid payload and usecase failure tests for creating tasks
- cover usecase failure when fetching tasks
- ensure tests reset mocks after each run

## Testing
- `npm test` *(fails: PrismaClient is not a constructor / @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9b723a00832b8dfa3fe1743496e4