### PR TITLE
test: add unit tests for task services

### DIFF
--- a/src/backend/services/tarefas/__tests__/delete-task.service.spec.ts
+++ b/src/backend/services/tarefas/__tests__/delete-task.service.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { deleteTask } from '@/backend/services/tarefas/delete-task'
+
+const originalFetch = global.fetch
+const originalEnv = process.env.NEXT_PUBLIC_API_URL
+
+afterEach(() => {
+  global.fetch = originalFetch
+  process.env.NEXT_PUBLIC_API_URL = originalEnv
+  vi.clearAllMocks()
+})
+
+describe('deleteTask service', () => {
+  it('envia requisição DELETE com headers corretos', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = fetchMock as any
+    process.env.NEXT_PUBLIC_API_URL = 'http://api'
+
+    await deleteTask('123')
+
+    expect(fetchMock).toHaveBeenCalledWith('http://api/api/tarefas/deletar', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: '123' })
+    })
+  })
+
+  it('lança erro com mensagem da API quando fetch falha', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, json: () => Promise.resolve({ message: 'falha' }) })
+    global.fetch = fetchMock as any
+
+    await expect(deleteTask('1')).rejects.toThrow('falha')
+  })
+
+  it('lança erro genérico quando fetch falha sem mensagem', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, json: () => Promise.reject(new Error('bad')) })
+    global.fetch = fetchMock as any
+
+    await expect(deleteTask('1')).rejects.toThrow('Erro ao excluir tarefa')
+  })
+})
+

--- a/src/backend/services/tarefas/__tests__/update-task.service.spec.ts
+++ b/src/backend/services/tarefas/__tests__/update-task.service.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { updateTask, type UpdateTaskInput } from '@/backend/services/tarefas/update-task'
+
+const mockGetUser = vi.fn()
+
+vi.mock('@/lib/client', () => ({
+  createClient: () => ({
+    auth: { getUser: mockGetUser }
+  })
+}))
+
+const originalFetch = global.fetch
+
+afterEach(() => {
+  global.fetch = originalFetch
+  vi.clearAllMocks()
+})
+
+describe('updateTask service', () => {
+  const baseInput: UpdateTaskInput = {
+    id: '1',
+    titulo: 't',
+    descricao: 'd',
+    prioridade: 'alta',
+    responsavelId: 'r1',
+    associacaoId: 'a1',
+    tipoId: 'tp1'
+  }
+
+  it('envia requisição PUT com headers e corpo corretos', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = fetchMock as any
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user1' } } })
+
+    await updateTask(baseInput)
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/tarefas/editar', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...baseInput, criadorId: 'user1' })
+    })
+  })
+
+  it('lança erro com mensagem da API quando fetch falha', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, json: () => Promise.resolve({ message: 'erro api' }) })
+    global.fetch = fetchMock as any
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user1' } } })
+
+    await expect(updateTask(baseInput)).rejects.toThrow('erro api')
+  })
+
+  it('lança erro quando usuário não autenticado', async () => {
+    const fetchMock = vi.fn()
+    global.fetch = fetchMock as any
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    await expect(updateTask(baseInput)).rejects.toThrow('Usuário não autenticado')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+


### PR DESCRIPTION
## Summary
- add deleteTask service tests verifying headers and error handling
- add updateTask service tests with mocked Supabase auth and fetch

## Testing
- `npm test` *(fails: PrismaClient is not a constructor)*
- `npx vitest run src/backend/services/tarefas/__tests__/delete-task.service.spec.ts src/backend/services/tarefas/__tests__/update-task.service.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ae9f69b434832b92d7a3d4d588013b