### PR TITLE
test: add validator schemas tests

### DIFF
--- a/src/backend/shared/validators/__tests__/buscarAssociacoes.validator.spec.ts
+++ b/src/backend/shared/validators/__tests__/buscarAssociacoes.validator.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { buscarAssociacoesSchema } from '@/backend/shared/validators/buscarAssociacoes';
+
+describe('buscarAssociacoesSchema', () => {
+  it('valida dados válidos', () => {
+    const result = buscarAssociacoesSchema.safeParse({
+      page: '2',
+      perPage: '5',
+      nome: 'abc',
+      cidade: 'xyz',
+      estado: 'SP',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      page: 2,
+      perPage: 5,
+      nome: 'abc',
+      cidade: 'xyz',
+      estado: 'SP',
+    });
+  });
+
+  it('rejeita perPage maior que 100', () => {
+    const result = buscarAssociacoesSchema.safeParse({ perPage: '101' });
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe(
+      'Too big: expected number to be <=100'
+    );
+  });
+});

--- a/src/backend/shared/validators/__tests__/buscarColaboradores.validator.spec.ts
+++ b/src/backend/shared/validators/__tests__/buscarColaboradores.validator.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { buscarColaboradoresSchema } from '@/backend/shared/validators/buscarColaboradores';
+
+describe('buscarColaboradoresSchema', () => {
+  it('aceita dados válidos', () => {
+    const result = buscarColaboradoresSchema.safeParse({
+      page: '3',
+      perPage: '20',
+      nome: 'Ana',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      page: 3,
+      perPage: 20,
+      nome: 'Ana',
+    });
+  });
+
+  it('rejeita perPage maior que 100', () => {
+    const result = buscarColaboradoresSchema.safeParse({ perPage: '101' });
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe(
+      'Too big: expected number to be <=100'
+    );
+  });
+
+  it('rejeita nome não string', () => {
+    const result = buscarColaboradoresSchema.safeParse({ nome: 123 as any });
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe(
+      'Invalid input: expected string, received number'
+    );
+  });
+});

--- a/src/backend/shared/validators/__tests__/buscarTarefas.validator.spec.ts
+++ b/src/backend/shared/validators/__tests__/buscarTarefas.validator.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { buscarTarefasSchema } from '@/backend/shared/validators/buscarTarefas';
+
+const uuid = '4e6e1b70-a267-4810-9e78-5dd4034e4466';
+
+describe('buscarTarefasSchema', () => {
+  it('aceita dados válidos', () => {
+    const result = buscarTarefasSchema.safeParse({
+      page: '2',
+      perPage: '5',
+      titulo: 'abc',
+      statusId: uuid,
+      prioridade: 'alta',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      page: 2,
+      perPage: 5,
+      titulo: 'abc',
+      statusId: uuid,
+      prioridade: 'alta',
+    });
+  });
+
+  it('rejeita perPage maior que 100', () => {
+    const result = buscarTarefasSchema.safeParse({ perPage: '101' });
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe(
+      'Too big: expected number to be <=100'
+    );
+  });
+
+  it('rejeita statusId inválido', () => {
+    const result = buscarTarefasSchema.safeParse({ statusId: 'invalid-uuid' });
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe('Invalid UUID');
+  });
+});

--- a/src/backend/shared/validators/__tests__/buscarTipos.validator.spec.ts
+++ b/src/backend/shared/validators/__tests__/buscarTipos.validator.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { buscarTiposSchema } from '@/backend/shared/validators/buscarTipos';
+
+describe('buscarTiposSchema', () => {
+  it('aceita dados válidos', () => {
+    const result = buscarTiposSchema.safeParse({
+      page: '2',
+      perPage: '10',
+      nome: 'abc',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      page: 2,
+      perPage: 10,
+      nome: 'abc',
+    });
+  });
+
+  it('rejeita perPage maior que 100', () => {
+    const result = buscarTiposSchema.safeParse({ perPage: '101' });
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe(
+      'Too big: expected number to be <=100'
+    );
+  });
+});

--- a/src/backend/shared/validators/__tests__/deletarTarefa.validator.spec.ts
+++ b/src/backend/shared/validators/__tests__/deletarTarefa.validator.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { deletarTarefaSchema } from '@/backend/shared/validators/deletarTarefa';
+
+const uuid = '4e6e1b70-a267-4810-9e78-5dd4034e4466';
+
+describe('deletarTarefaSchema', () => {
+  it('aceita id válido', () => {
+    const result = deletarTarefaSchema.safeParse({ id: uuid });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ id: uuid });
+  });
+
+  it('rejeita id ausente', () => {
+    const result = deletarTarefaSchema.safeParse({} as any);
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe(
+      'Invalid input: expected string, received undefined'
+    );
+  });
+
+  it('rejeita id inválido', () => {
+    const result = deletarTarefaSchema.safeParse({ id: 'invalid' });
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe('Invalid UUID');
+  });
+});

--- a/src/backend/shared/validators/__tests__/editarTarefa.validator.spec.ts
+++ b/src/backend/shared/validators/__tests__/editarTarefa.validator.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { editarTarefaSchema } from '@/backend/shared/validators/editarTarefa';
+
+const uuid = '4e6e1b70-a267-4810-9e78-5dd4034e4466';
+
+describe('editarTarefaSchema', () => {
+  it('aceita dados válidos', () => {
+    const result = editarTarefaSchema.safeParse({ id: uuid, titulo: 'abc' });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ id: uuid, titulo: 'abc' });
+  });
+
+  it('rejeita id ausente', () => {
+    const result = editarTarefaSchema.safeParse({} as any);
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe(
+      'Invalid input: expected string, received undefined'
+    );
+  });
+
+  it('rejeita id inválido', () => {
+    const result = editarTarefaSchema.safeParse({ id: 'invalid' });
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe('Invalid UUID');
+  });
+});

--- a/src/backend/shared/validators/__tests__/tarefa.validator.spec.ts
+++ b/src/backend/shared/validators/__tests__/tarefa.validator.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { tarefaSchema } from '@/backend/shared/validators/tarefa';
+
+const uuid = '4e6e1b70-a267-4810-9e78-5dd4034e4466';
+const makeValid = () => ({
+  titulo: 't',
+  descricao: 'd',
+  prioridade: 'alta',
+  associacaoId: uuid,
+  criadorId: uuid,
+  responsavelId: uuid,
+  statusId: uuid,
+  tipoId: uuid,
+  data_inicio: '2024-01-01',
+  data_fim: '2024-01-02',
+});
+
+describe('tarefaSchema', () => {
+  it('aceita dados válidos', () => {
+    const input = makeValid();
+    const result = tarefaSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      ...input,
+      data_inicio: new Date('2024-01-01'),
+      data_fim: new Date('2024-01-02'),
+    });
+  });
+
+  it('rejeita titulo ausente', () => {
+    const { titulo, ...rest } = makeValid();
+    const result = tarefaSchema.safeParse(rest as any);
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe(
+      'Invalid input: expected string, received undefined'
+    );
+  });
+
+  it('rejeita associacaoId inválido', () => {
+    const input = { ...makeValid(), associacaoId: 'invalid' };
+    const result = tarefaSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    expect(result.error.issues[0].message).toBe('Invalid UUID');
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest specs for all validator schemas
- cover valid and invalid cases with error messages

## Testing
- `npm test` *(fails: PrismaClient is not a constructor)*
- `npx vitest run src/backend/shared/validators/__tests__`


------
https://chatgpt.com/codex/tasks/task_e_68aea0648c7c832b9d33fe07a4299f8e