### PR TITLE
test: improve buscarTarefas repository tests

### DIFF
--- a/src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts
+++ b/src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 vi.mock('@prisma/client')
 
@@ -7,15 +7,22 @@ import { buscarTarefas } from '@/backend/repositories/tarefas/buscarTarefas.repo
 import { BuscarTarefasInput } from '@/backend/shared/validators/buscarTarefas'
 
 describe('buscarTarefas.repository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.tarefa.findMany).mockResolvedValue([])
+    vi.mocked(prisma.tarefa.count).mockResolvedValue(0)
+  })
+
   afterEach(() => {
     vi.clearAllMocks()
   })
 
-  it('chama prisma com filtros e paginacao', async () => {
-    vi.mocked(prisma.tarefa.findMany).mockResolvedValue([])
-    vi.mocked(prisma.tarefa.count).mockResolvedValue(0)
+  it('chama prisma com filtros e paginacao e retorna tarefas e total', async () => {
+    const tarefas = [{ id: '1' } as any]
+    vi.mocked(prisma.tarefa.findMany).mockResolvedValue(tarefas)
+    vi.mocked(prisma.tarefa.count).mockResolvedValue(tarefas.length)
 
-    await buscarTarefas({ page: 2, perPage: 5, statusId: '1', titulo: 'test', prioridade: 'alta' } as unknown as BuscarTarefasInput)
+    const result = await buscarTarefas({ page: 2, perPage: 5, statusId: '1', titulo: 'test', prioridade: 'alta' } as unknown as BuscarTarefasInput)
     expect(prisma.tarefa.findMany).toHaveBeenCalledWith({
       where: { statusid: '1', prioridade: 'alta', titulo: { contains: 'test', mode: 'insensitive' } },
       skip: 5,
@@ -25,5 +32,14 @@ describe('buscarTarefas.repository', () => {
     expect(prisma.tarefa.count).toHaveBeenCalledWith({
       where: { statusid: '1', prioridade: 'alta', titulo: { contains: 'test', mode: 'insensitive' } }
     })
+    expect(result).toEqual({ tarefas, total: tarefas.length })
+  })
+
+  it('propaga erro se prisma.tarefa.findMany falhar', async () => {
+    const error = new Error('db error')
+    vi.mocked(prisma.tarefa.findMany).mockRejectedValue(error)
+    vi.mocked(prisma.tarefa.count).mockResolvedValue(0)
+
+    await expect(buscarTarefas({ page: 1, perPage: 10 } as unknown as BuscarTarefasInput)).rejects.toThrow(error)
   })
 })


### PR DESCRIPTION
## Summary
- add beforeEach/afterEach to isolate prisma mocks
- ensure buscarTarefas returns mocked data and total
- assert error propagation when prisma findMany rejects

## Testing
- `npm test src/backend/repositories/tarefas/__tests__/buscarTarefas.repository.spec.ts`
- `npm test` *(fails: PrismaClient is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68aea42a265c832bb09045ce52497e01