### PR TITLE
Use optional chaining in E2E test cleanup

### DIFF
--- a/src/backend/tests/buscarColaboradores.e2e.spec.ts
+++ b/src/backend/tests/buscarColaboradores.e2e.spec.ts
@@ -12,7 +12,7 @@ describe('GET /api/colaboradores/buscar', () => {
   })
 
   afterEach(async () => {
-    await ctx.close()
+    await ctx?.close()
   })
 
   it('retorna 200 e lista colaboradores', async () => {

--- a/src/backend/tests/buscarTarefas.e2e.spec.ts
+++ b/src/backend/tests/buscarTarefas.e2e.spec.ts
@@ -37,7 +37,7 @@ describe('GET /api/tarefas/buscar', () => {
   afterEach(async () => {
     vi.restoreAllMocks()
     vi.clearAllMocks()
-    await ctx.close()
+    await ctx?.close()
   })
 
   it('retorna 200 e lista tarefas', async () => {

--- a/src/backend/tests/buscarTipos.e2e.spec.ts
+++ b/src/backend/tests/buscarTipos.e2e.spec.ts
@@ -15,7 +15,7 @@ describe('GET /api/tipos/buscar', () => {
   })
 
   afterEach(async () => {
-    await ctx.close()
+    await ctx?.close()
   })
 
   it('retorna 200 e filtra tipos', async () => {

--- a/src/backend/tests/criarTarefa.e2e.spec.ts
+++ b/src/backend/tests/criarTarefa.e2e.spec.ts
@@ -20,7 +20,7 @@ describe('POST /api/tarefas/criar', () => {
   afterEach(async () => {
     vi.restoreAllMocks()
     vi.clearAllMocks()
-    await ctx.close()
+    await ctx?.close()
   })
 
   it('retorna 201 e cria tarefa', async () => {


### PR DESCRIPTION
## Summary
- Safely close test context in all backend E2E specs

## Testing
- `npm test` *(fails: Prisma schema validation - P1012)*

------
https://chatgpt.com/codex/tasks/task_e_68af3baf0efc832b901257fb95973d1e