### PR TITLE
feat(prisma): add status_criados relation to usuario

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -313,7 +313,7 @@ model status {
   updatedat DateTime? @default(now()) @db.Timestamptz(6)
 
   // Agora referencia o perfil (public.usuario), não auth.users
-  criador   usuario?  @relation(fields: [criadorid], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  criador   usuario?  @relation("status_criadoridTousuario", fields: [criadorid], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   tarefa    tarefa[]
 
@@ -374,6 +374,7 @@ model usuario {
   // back-relations
   tarefa_tarefa_criadoridTousuario     tarefa[] @relation("tarefa_criadoridTousuario")
   tarefa_tarefa_responsavelidTousuario tarefa[] @relation("tarefa_responsavelidTousuario")
+  status_criados                       status[] @relation("status_criadoridTousuario")
 
   @@schema("public")
 }


### PR DESCRIPTION
## Summary
- link usuario with statuses via status_criados
- name status -> usuario relation

## Testing
- `pnpm prisma format --schema /tmp/schema.prisma`


------
https://chatgpt.com/codex/tasks/task_e_68af3fb62df0832b8a40ba958f9a4610