### PR TITLE
fix: correct AlertDialog import path

### DIFF
--- a/src/app/(protected)/dashboard/tarefas/components/DataTableRowActions.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/DataTableRowActions.tsx
@@ -32,7 +32,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from "@/components/ui/Alert-dialog";
+} from "@/components/ui/AlertDialog";
 import { useNotification } from "@/components/NotificationProvider";
 import { deleteTask } from "@/backend/services/tarefas";
 

--- a/src/app/(protected)/dashboard/tarefas/components/EditTaskDialog.tsx
+++ b/src/app/(protected)/dashboard/tarefas/components/EditTaskDialog.tsx
@@ -48,7 +48,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from "@/components/ui/Alert-dialog";
+} from "@/components/ui/AlertDialog";
 
 const formSchema = z.object({
   title: z.string().min(1, { message: "Título é obrigatório" }),


### PR DESCRIPTION
## Summary
- fix import path for AlertDialog component in task dashboard

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68af6b95d8ec832bbc310bb8311a6b38