### PR TITLE
fix: build absolute URL for server fetch

### DIFF
--- a/src/app/(protected)/dashboard/tarefas/page.tsx
+++ b/src/app/(protected)/dashboard/tarefas/page.tsx
@@ -1,78 +1,94 @@
 // app/(private)/tarefas/page.tsx
-import { columns, type Task } from "./components/columns"
-import { DataTable } from "./components/DataTable"
+import { columns, type Task } from './components/columns';
+import { DataTable } from './components/DataTable';
 
 // Helper robusto para JSON
+// Node's global `fetch` exige URLs absolutas quando executado no servidor.
+// Construímos a URL final a partir de `NEXT_PUBLIC_API_URL` (ou localhost)
+// para evitar "Failed to parse URL" ao usar caminhos relativos.
 async function fetchJSON<T>(url: string) {
-  const res = await fetch(url, {
-    cache: "no-store",
-    headers: { accept: "application/json" },
-  })
+  const base = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+  const fullUrl = new URL(url, base);
+  const res = await fetch(fullUrl, {
+    cache: 'no-store',
+    headers: { accept: 'application/json' },
+  });
 
-  const ct = res.headers.get("content-type") || ""
-  const text = await res.text()
+  const ct = res.headers.get('content-type') || '';
+  const text = await res.text();
 
   if (!res.ok) {
-    console.error(`[fetchJSON] ${url} -> HTTP ${res.status}`, text.slice(0, 300))
-    throw new Error(`HTTP ${res.status} on ${url}`)
+    console.error(
+      `[fetchJSON] ${url} -> HTTP ${res.status}`,
+      text.slice(0, 300)
+    );
+    throw new Error(`HTTP ${res.status} on ${url}`);
   }
 
-  if (!ct.includes("application/json")) {
-    console.error(`[fetchJSON] ${url} -> Non-JSON content-type: ${ct}; preview:`, text.slice(0, 200))
-    throw new Error(`Non-JSON response from ${url}`)
+  if (!ct.includes('application/json')) {
+    console.error(
+      `[fetchJSON] ${url} -> Non-JSON content-type: ${ct}; preview:`,
+      text.slice(0, 200)
+    );
+    throw new Error(`Non-JSON response from ${url}`);
   }
 
   try {
-    return JSON.parse(text) as T
+    return JSON.parse(text) as T;
   } catch (e: unknown) {
-    console.error(`[fetchJSON] ${url} -> Invalid JSON; preview:`, text.slice(0, 200))
-    throw e
+    console.error(
+      `[fetchJSON] ${url} -> Invalid JSON; preview:`,
+      text.slice(0, 200)
+    );
+    throw e;
   }
 }
 
 export default async function TarefasPage() {
   interface TarefaApi {
-    id: string
-    createdat: string
-    titulo: string
-    descricao: string
-    status?: { nome: string } | null
-    prioridade?: string | null
-    data_fim?: string | null
-    responsavelid?: string | null
-    associacaoid?: string | null
-    tipoid?: string | null
+    id: string;
+    createdat: string;
+    titulo: string;
+    descricao: string;
+    status?: { nome: string } | null;
+    prioridade?: string | null;
+    data_fim?: string | null;
+    responsavelid?: string | null;
+    associacaoid?: string | null;
+    tipoid?: string | null;
   }
 
   interface AssociacaoApi {
-    id: string
-    nome: string
+    id: string;
+    nome: string;
   }
 
-  let tarefas: TarefaApi[] = []
-  let associacoes: AssociacaoApi[] = []
+  let tarefas: TarefaApi[] = [];
+  let associacoes: AssociacaoApi[] = [];
 
   try {
     // Use rotas relativas pra aproveitar sessão/cookies e evitar CORS
     const [tarefasData, associacoesData] = await Promise.all([
-      fetchJSON<{ tarefas?: TarefaApi[] }>("/api/tarefas/buscar"),
-      fetchJSON<{ associacoes?: AssociacaoApi[] }>("/api/associacoes/buscar?page=1&perPage=100"),
-    ])
+      fetchJSON<{ tarefas?: TarefaApi[] }>('/api/tarefas/buscar'),
+      fetchJSON<{ associacoes?: AssociacaoApi[] }>(
+        '/api/associacoes/buscar?page=1&perPage=100'
+      ),
+    ]);
 
-    tarefas = tarefasData?.tarefas ?? []
-    associacoes = associacoesData?.associacoes ?? []
+    tarefas = tarefasData?.tarefas ?? [];
+    associacoes = associacoesData?.associacoes ?? [];
   } catch (error: unknown) {
-    console.error("Erro ao buscar dados de tarefas/associações:", error)
+    console.error('Erro ao buscar dados de tarefas/associações:', error);
     // segue com arrays vazios pra não quebrar a página
   }
 
   const associacoesMap = Object.fromEntries(
     (associacoes ?? []).map((a: AssociacaoApi) => [a.id, a.nome])
-  )
+  );
 
   const tasks: Task[] = (tarefas ?? []).map((t: TarefaApi) => ({
     id: t.id,
-    createdAt: t.createdat,           // confira o nome exato que a API retorna (created_at vs createdat)
+    createdAt: t.createdat, // confira o nome exato que a API retorna (created_at vs createdat)
     title: t.titulo,
     description: t.descricao,
     status: t.status?.nome ?? null,
@@ -83,12 +99,12 @@ export default async function TarefasPage() {
     associacaoId: t.associacaoid ?? null,
     associacao: associacoesMap[t.associacaoid] ?? null,
     tipoId: t.tipoid ?? null,
-  }))
+  }));
 
   return (
     <div className="p-6">
       <h1 className="text-2xl font-semibold mb-4">Listagem de Tarefas</h1>
       <DataTable columns={columns} data={tasks} />
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- avoid "Failed to parse URL" by building absolute URL from NEXT_PUBLIC_API_URL in dashboard tasks page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68af9b3207ec832ba21b248dd8fa74af