### PR TITLE
refactor: centralize HTTP client logic

### DIFF
--- a/src/services/http-client.ts
+++ b/src/services/http-client.ts
@@ -1,0 +1,139 @@
+export type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+
+export interface RequestOptions {
+  method?: HttpMethod
+  headers?: HeadersInit
+  body?: unknown
+}
+
+type TokenProvider = () => string | null | undefined | Promise<string | null | undefined>
+type UrlResolver = (path: string) => string
+
+interface HttpClientConfig {
+  getToken?: TokenProvider
+  resolveUrl: UrlResolver
+  loggerLabel?: string
+}
+
+export class HttpClient {
+  private readonly tokenProvider?: TokenProvider
+  private readonly resolveUrl: UrlResolver
+  private readonly loggerLabel: string
+
+  constructor({ getToken, resolveUrl, loggerLabel }: HttpClientConfig) {
+    this.tokenProvider = getToken
+    this.resolveUrl = resolveUrl
+    this.loggerLabel = loggerLabel ?? 'HTTP'
+  }
+
+  requestJson = async <T>(path: string, opts: RequestOptions = {}): Promise<T> => {
+    const method = opts.method ?? 'GET'
+    const url = this.resolveUrl(path)
+    const headers = await this.createBaseHeaders()
+    headers.set('Content-Type', 'application/json')
+    this.mergeHeaders(headers, opts.headers)
+
+    const res = await fetch(url, {
+      method,
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+      cache: 'no-store',
+    })
+
+    const ct = res.headers.get('content-type') || ''
+    const raw = await res.text()
+    const maybeJson = ct.includes('application/json')
+    let parsed: unknown = undefined
+    if (maybeJson) {
+      try {
+        parsed = JSON.parse(raw)
+      } catch {}
+    }
+
+    if (!res.ok) {
+      const message = this.extractApiMessage(parsed, raw)
+      this.log(`[${this.loggerLabel} ${method}] ${path} -> ${res.status}: ${message}`)
+      throw new Error(message)
+    }
+
+    if (!maybeJson) {
+      this.log(`[${this.loggerLabel}] ${path} -> Non-JSON content-type: ${ct}; preview:`, raw.slice(0, 200))
+      throw new Error('Non-JSON response')
+    }
+
+    if (parsed === undefined) {
+      this.log(`[${this.loggerLabel}] ${path} -> Invalid JSON; preview:`, raw.slice(0, 200))
+      throw new Error('Invalid JSON response')
+    }
+
+    return parsed as T
+  }
+
+  requestVoid = async (path: string, opts: RequestOptions = {}): Promise<void> => {
+    const method = opts.method ?? 'DELETE'
+    const url = this.resolveUrl(path)
+    const headers = await this.createBaseHeaders()
+    this.mergeHeaders(headers, opts.headers)
+
+    const res = await fetch(url, {
+      method,
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+      cache: 'no-store',
+    })
+
+    if (!res.ok) {
+      const ct = res.headers.get('content-type') || ''
+      const raw = await res.text()
+      let parsed: unknown = undefined
+      if (ct.includes('application/json')) {
+        try {
+          parsed = JSON.parse(raw)
+        } catch {}
+      }
+
+      const message = this.extractApiMessage(parsed, raw)
+      this.log(`[${this.loggerLabel} ${method}] ${path} -> ${res.status}: ${message}`)
+      throw new Error(message)
+    }
+  }
+
+  private async createBaseHeaders(): Promise<Headers> {
+    const headers = new Headers({ Accept: 'application/json' })
+    const token = this.tokenProvider ? await this.tokenProvider() : undefined
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`)
+    }
+    return headers
+  }
+
+  private mergeHeaders(base: Headers, extra?: HeadersInit): Headers {
+    if (!extra) return base
+    if (extra instanceof Headers) {
+      extra.forEach((v, k) => base.set(k, v))
+    } else if (Array.isArray(extra)) {
+      extra.forEach(([k, v]) => base.set(k, v))
+    } else {
+      Object.entries(extra).forEach(([k, v]) => base.set(k, String(v)))
+    }
+    return base
+  }
+
+  private extractApiMessage(payload: unknown, fallback: string): string {
+    if (payload && typeof payload === 'object') {
+      if ('message' in payload && typeof (payload as { message?: unknown }).message === 'string') {
+        return (payload as { message?: string }).message as string
+      }
+      if ('error' in payload && typeof (payload as { error?: unknown }).error === 'string') {
+        return (payload as { error?: string }).error as string
+      }
+    }
+    return fallback
+  }
+
+  private log(message?: unknown, ...optionalParams: unknown[]) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(message, ...optionalParams)
+    }
+  }
+}

--- a/src/services/http-server.ts
+++ b/src/services/http-server.ts
@@ -1,92 +1,22 @@
 import { apiUrl, API_BASE_URL } from '@/lib/endpoints'
 import { getServerAccessToken } from '@/lib/auth-server'
 
-export type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+import { HttpClient } from './http-client'
 
-export interface RequestOptions {
-  method?: HttpMethod
-  headers?: HeadersInit
-  body?: unknown
+export type { HttpMethod, RequestOptions } from './http-client'
+
+const resolveServerUrl = (path: string): string => {
+  if (path.startsWith('/api/')) {
+    return new URL(path.replace(/^\/api\//, ''), API_BASE_URL).toString()
+  }
+  return apiUrl(path)
 }
 
-function mergeHeaders(base: Headers, extra?: HeadersInit) {
-  if (!extra) return base
-  if (extra instanceof Headers) {
-    extra.forEach((v, k) => base.set(k, v))
-  } else if (Array.isArray(extra)) {
-    extra.forEach(([k, v]) => base.set(k, v))
-  } else {
-    Object.entries(extra).forEach(([k, v]) => base.set(k, String(v)))
-  }
-  return base
-}
+export const httpServerClient = new HttpClient({
+  getToken: getServerAccessToken,
+  resolveUrl: resolveServerUrl,
+  loggerLabel: 'HTTP(S)',
+})
 
-async function buildHeaders(extra?: HeadersInit): Promise<Headers> {
-  const token = await getServerAccessToken()
-  const h = new Headers({ Accept: 'application/json' })
-  if (token) h.set('Authorization', `Bearer ${token}`)
-  return mergeHeaders(h, extra)
-}
-
-export async function requestJsonServer<T>(path: string, opts: RequestOptions = {}): Promise<T> {
-  // On the server, Node fetch requires absolute URLs.
-  // For proxy paths like "/api/...", resolve against external API base.
-  const url = path.startsWith('/api/')
-    ? new URL(path.replace(/^\/api\//, ''), API_BASE_URL).toString()
-    : apiUrl(path)
-  const headers = await buildHeaders({ 'Content-Type': 'application/json', ...(opts.headers || {}) })
-  const res = await fetch(url, {
-    method: opts.method || 'GET',
-    headers,
-    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
-    cache: 'no-store',
-  })
-
-  const ct = res.headers.get('content-type') || ''
-  const raw = await res.text()
-  const maybeJson = ct.includes('application/json')
-  let parsed: unknown = undefined
-  if (maybeJson) {
-    try { parsed = JSON.parse(raw) } catch {}
-  }
-
-  if (!res.ok) {
-    const apiMessage = (typeof parsed === 'object' && parsed && 'message' in parsed
-      ? (parsed as { message?: string }).message
-      : typeof parsed === 'object' && parsed && 'error' in parsed
-        ? (parsed as { error?: string }).error
-        : undefined) ?? raw
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(`[HTTP(S) ${opts.method || 'GET'}] ${path} -> ${res.status}: ${apiMessage}`)
-    }
-    throw new Error(apiMessage)
-  }
-
-  if (!maybeJson || parsed === undefined) {
-    throw new Error('Invalid JSON response')
-  }
-  return parsed as T
-}
-
-export async function requestVoidServer(path: string, opts: RequestOptions = {}): Promise<void> {
-  const url = path.startsWith('/api/')
-    ? new URL(path.replace(/^\/api\//, ''), API_BASE_URL).toString()
-    : apiUrl(path)
-  const headers = await buildHeaders({ ...(opts.headers || {}) })
-  const res = await fetch(url, {
-    method: opts.method || 'DELETE',
-    headers,
-    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
-    cache: 'no-store',
-  })
-  if (!res.ok) {
-    const ct = res.headers.get('content-type') || ''
-    const raw = await res.text()
-    const data = ct.includes('application/json') ? (() => { try { return JSON.parse(raw) } catch { return null } })() : null
-    const message = (data?.message ?? data?.error ?? raw) as string
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(`[HTTP(S) ${opts.method || 'DELETE'}] ${path} -> ${res.status}: ${message}`)
-    }
-    throw new Error(message)
-  }
-}
+export const requestJsonServer = httpServerClient.requestJson
+export const requestVoidServer = httpServerClient.requestVoid

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,95 +1,14 @@
 import { apiUrl } from '@/lib/endpoints'
 import { getAccessToken } from '@/lib/auth-client'
 
-export type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+import { HttpClient } from './http-client'
 
-export interface RequestOptions {
-  method?: HttpMethod
-  headers?: HeadersInit
-  body?: unknown
-}
+export type { HttpMethod, RequestOptions } from './http-client'
 
-function mergeHeaders(base: Headers, extra?: HeadersInit) {
-  if (!extra) return base
-  if (extra instanceof Headers) {
-    extra.forEach((v, k) => base.set(k, v))
-  } else if (Array.isArray(extra)) {
-    extra.forEach(([k, v]) => base.set(k, v))
-  } else {
-    Object.entries(extra).forEach(([k, v]) => base.set(k, String(v)))
-  }
-  return base
-}
+export const httpClient = new HttpClient({
+  getToken: getAccessToken,
+  resolveUrl: apiUrl,
+})
 
-async function buildHeaders(extra?: HeadersInit): Promise<Headers> {
-  const token = await getAccessToken()
-  const h = new Headers({ Accept: 'application/json' })
-  if (token) h.set('Authorization', `Bearer ${token}`)
-  return mergeHeaders(h, extra)
-}
-
-export async function requestJson<T>(path: string, opts: RequestOptions = {}): Promise<T> {
-  const url = apiUrl(path)
-  const headers = await buildHeaders({ 'Content-Type': 'application/json', ...(opts.headers || {}) })
-  const res = await fetch(url, {
-    method: opts.method || 'GET',
-    headers,
-    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
-    cache: 'no-store',
-  })
-
-  const ct = res.headers.get('content-type') || ''
-  const raw = await res.text()
-  const maybeJson = ct.includes('application/json')
-  let parsed: unknown = undefined
-  if (maybeJson) {
-    try { parsed = JSON.parse(raw) } catch {}
-  }
-
-  if (!res.ok) {
-    const apiMessage = (typeof parsed === 'object' && parsed && 'message' in parsed
-      ? (parsed as { message?: string }).message
-      : typeof parsed === 'object' && parsed && 'error' in parsed
-        ? (parsed as { error?: string }).error
-        : undefined) ?? raw
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(`[HTTP ${opts.method || 'GET'}] ${path} -> ${res.status}: ${apiMessage}`)
-    }
-    throw new Error(apiMessage)
-  }
-
-  if (!maybeJson) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(`[HTTP] ${path} -> Non-JSON content-type: ${ct}; preview:`, raw.slice(0, 200))
-    }
-    throw new Error('Non-JSON response')
-  }
-  if (parsed === undefined) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(`[HTTP] ${path} -> Invalid JSON; preview:`, raw.slice(0, 200))
-    }
-    throw new Error('Invalid JSON response')
-  }
-  return parsed as T
-}
-
-export async function requestVoid(path: string, opts: RequestOptions = {}): Promise<void> {
-  const url = apiUrl(path)
-  const headers = await buildHeaders({ ...(opts.headers || {}) })
-  const res = await fetch(url, {
-    method: opts.method || 'DELETE',
-    headers,
-    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
-    cache: 'no-store',
-  })
-  if (!res.ok) {
-    const ct = res.headers.get('content-type') || ''
-    const raw = await res.text()
-    const data = ct.includes('application/json') ? (() => { try { return JSON.parse(raw) } catch { return null } })() : null
-    const message = (data?.message ?? data?.error ?? raw) as string
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(`[HTTP ${opts.method || 'DELETE'}] ${path} -> ${res.status}: ${message}`)
-    }
-    throw new Error(message)
-  }
-}
+export const requestJson = httpClient.requestJson
+export const requestVoid = httpClient.requestVoid


### PR DESCRIPTION
## Summary
- add a shared `HttpClient` with token-aware headers and JSON/error handling utilities
- update browser and server HTTP helpers to export configured `HttpClient` instances and reuse the shared logic

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c862747260832ba60f712434f753ed