### PR TITLE
Add query string helper and reuse across services

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,31 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+type QueryPrimitive = string | number | boolean | Date;
+type QueryValue = QueryPrimitive | QueryPrimitive[] | null | undefined;
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
+}
+
+export function toQueryString(
+  record: Record<string, QueryValue>
+): URLSearchParams {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(record)) {
+    if (value == null) continue;
+
+    const values = Array.isArray(value) ? value : [value];
+
+    for (const item of values) {
+      if (item == null) continue;
+
+      const parsedValue =
+        item instanceof Date ? item.toISOString() : String(item);
+      params.append(key, parsedValue);
+    }
+  }
+
+  return params;
 }

--- a/src/services/associations.ts
+++ b/src/services/associations.ts
@@ -1,46 +1,71 @@
-import { requestJson, requestVoid } from './http'
-import type { Association, CreateAssociationDto, UpdateAssociationDto, Paginated } from '@/types/api'
+import { toQueryString } from '@/lib/utils';
+import { requestJson, requestVoid } from './http';
+import type {
+  Association,
+  CreateAssociationDto,
+  UpdateAssociationDto,
+  Paginated,
+} from '@/types/api';
 
 export interface ListAssociationsQuery {
-  sortOrder?: 'ASC' | 'DESC'
-  sortBy?: 'id' | 'name' | 'cnpj' | 'status'
-  limit?: number
-  page?: number
-  status?: boolean
-  cnpj?: string
-  name?: string
+  sortOrder?: 'ASC' | 'DESC';
+  sortBy?: 'id' | 'name' | 'cnpj' | 'status';
+  limit?: number;
+  page?: number;
+  status?: boolean;
+  cnpj?: string;
+  name?: string;
 }
 
-export async function listAssociations(q: ListAssociationsQuery = {}): Promise<Paginated<Association>> {
-  const params = new URLSearchParams()
-  if (q.sortOrder) params.set('sortOrder', q.sortOrder)
-  if (q.sortBy) params.set('sortBy', q.sortBy)
-  if (q.limit) params.set('limit', String(q.limit))
-  if (q.page) params.set('page', String(q.page))
-  if (typeof q.status === 'boolean') params.set('status', String(q.status))
-  if (q.cnpj) params.set('cnpj', q.cnpj)
-  if (q.name) params.set('name', q.name)
-  return requestJson<Paginated<Association>>(`/api/association?${params.toString()}`)
+export async function listAssociations(
+  q: ListAssociationsQuery = {}
+): Promise<Paginated<Association>> {
+  const params = toQueryString({
+    sortOrder: q.sortOrder,
+    sortBy: q.sortBy,
+    limit: q.limit ?? undefined,
+    page: q.page ?? undefined,
+    status: typeof q.status === 'boolean' ? q.status : undefined,
+    cnpj: q.cnpj || undefined,
+    name: q.name || undefined,
+  });
+  return requestJson<Paginated<Association>>(
+    `/api/association?${params.toString()}`
+  );
 }
 
 // Server-side variant moved to associations.server.ts to avoid client bundles pulling server-only code.
 
-export async function createAssociation(body: CreateAssociationDto): Promise<Association> {
-  return requestJson<Association>('/api/association', { method: 'POST', body })
+export async function createAssociation(
+  body: CreateAssociationDto
+): Promise<Association> {
+  return requestJson<Association>('/api/association', { method: 'POST', body });
 }
 
 export async function getAssociationById(id: string): Promise<Association> {
-  return requestJson<Association>(`/api/association/id/${encodeURIComponent(id)}`)
+  return requestJson<Association>(
+    `/api/association/id/${encodeURIComponent(id)}`
+  );
 }
 
 export async function getAssociationByCnpj(cnpj: string): Promise<Association> {
-  return requestJson<Association>(`/api/association/cnpj/${encodeURIComponent(cnpj)}`)
+  return requestJson<Association>(
+    `/api/association/cnpj/${encodeURIComponent(cnpj)}`
+  );
 }
 
-export async function updateAssociation(id: string, body: UpdateAssociationDto): Promise<void> {
-  await requestJson<void>(`/api/association/${encodeURIComponent(id)}`, { method: 'PATCH', body })
+export async function updateAssociation(
+  id: string,
+  body: UpdateAssociationDto
+): Promise<void> {
+  await requestJson<void>(`/api/association/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    body,
+  });
 }
 
 export async function deleteAssociation(id: string): Promise<void> {
-  await requestVoid(`/api/association/${encodeURIComponent(id)}`, { method: 'DELETE' })
+  await requestVoid(`/api/association/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
 }

--- a/src/services/tarefas/list-tasks.ts
+++ b/src/services/tarefas/list-tasks.ts
@@ -1,24 +1,33 @@
-import { requestJson } from '@/services/http'
-import { requestJsonServer } from '@/services/http-server'
-import type { TaskApi as TaskListItem, Paginated } from '@/types/api'
+import { toQueryString } from '@/lib/utils';
+import { requestJson } from '@/services/http';
+import { requestJsonServer } from '@/services/http-server';
+import type { TaskApi as TaskListItem, Paginated } from '@/types/api';
 
 // Types imported from shared DTOs
 
 export interface ListTasksQuery {
-  page?: number
-  limit?: number
+  page?: number;
+  limit?: number;
 }
 
-export async function listTasks(q: ListTasksQuery = {}): Promise<Paginated<TaskListItem>> {
-  const params = new URLSearchParams()
-  if (q.page) params.set('page', String(q.page))
-  if (q.limit) params.set('limit', String(q.limit))
-  return requestJson<Paginated<TaskListItem>>(`/api/task?${params.toString()}`)
+export async function listTasks(
+  q: ListTasksQuery = {}
+): Promise<Paginated<TaskListItem>> {
+  const params = toQueryString({
+    page: q.page ?? undefined,
+    limit: q.limit ?? undefined,
+  });
+  return requestJson<Paginated<TaskListItem>>(`/api/task?${params.toString()}`);
 }
 
-export async function listTasksServer(q: ListTasksQuery = {}): Promise<Paginated<TaskListItem>> {
-  const params = new URLSearchParams()
-  if (q.page) params.set('page', String(q.page))
-  if (q.limit) params.set('limit', String(q.limit))
-  return requestJsonServer<Paginated<TaskListItem>>(`/api/task?${params.toString()}`)
+export async function listTasksServer(
+  q: ListTasksQuery = {}
+): Promise<Paginated<TaskListItem>> {
+  const params = toQueryString({
+    page: q.page ?? undefined,
+    limit: q.limit ?? undefined,
+  });
+  return requestJsonServer<Paginated<TaskListItem>>(
+    `/api/task?${params.toString()}`
+  );
 }

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -1,46 +1,64 @@
-import { requestJson, requestVoid } from './http'
-import type { User, UserRole, Paginated, CreateUserDto, UpdateUserDto } from '@/types/api'
+import { toQueryString } from '@/lib/utils';
+import { requestJson, requestVoid } from './http';
+import type {
+  User,
+  UserRole,
+  Paginated,
+  CreateUserDto,
+  UpdateUserDto,
+} from '@/types/api';
 
 export interface ListUsersQuery {
-  sortOrder?: 'ASC' | 'DESC'
-  sortBy?: 'id' | 'name' | 'email' | 'role'
-  limit?: number
-  page?: number
-  role?: UserRole
-  email?: string
-  name?: string
+  sortOrder?: 'ASC' | 'DESC';
+  sortBy?: 'id' | 'name' | 'email' | 'role';
+  limit?: number;
+  page?: number;
+  role?: UserRole;
+  email?: string;
+  name?: string;
 }
 
-export async function listUsers(q: ListUsersQuery = {}): Promise<Paginated<User>> {
-  const params = new URLSearchParams()
-  if (q.sortOrder) params.set('sortOrder', q.sortOrder)
-  if (q.sortBy) params.set('sortBy', q.sortBy)
-  if (q.limit) params.set('limit', String(q.limit))
-  if (q.page) params.set('page', String(q.page))
-  if (q.role) params.set('role', q.role)
-  if (q.email) params.set('email', q.email)
-  if (q.name) params.set('name', q.name)
-  return requestJson<Paginated<User>>(`/api/user?${params.toString()}`)
+export async function listUsers(
+  q: ListUsersQuery = {}
+): Promise<Paginated<User>> {
+  const params = toQueryString({
+    sortOrder: q.sortOrder,
+    sortBy: q.sortBy,
+    limit: q.limit ?? undefined,
+    page: q.page ?? undefined,
+    role: q.role,
+    email: q.email || undefined,
+    name: q.name || undefined,
+  });
+  return requestJson<Paginated<User>>(`/api/user?${params.toString()}`);
 }
 
 // Server-side variant moved to users.server.ts to avoid client bundles pulling server-only code.
 
 export async function createUser(body: CreateUserDto): Promise<User> {
-  return requestJson<User>('/api/user', { method: 'POST', body })
+  return requestJson<User>('/api/user', { method: 'POST', body });
 }
 
 export async function getUserById(id: string): Promise<User> {
-  return requestJson<User>(`/api/user/id/${encodeURIComponent(id)}`)
+  return requestJson<User>(`/api/user/id/${encodeURIComponent(id)}`);
 }
 
 export async function getUserByEmail(email: string): Promise<User> {
-  return requestJson<User>(`/api/user/email/${encodeURIComponent(email)}`)
+  return requestJson<User>(`/api/user/email/${encodeURIComponent(email)}`);
 }
 
-export async function updateUser(id: string, body: UpdateUserDto): Promise<void> {
-  await requestJson<void>(`/api/user/${encodeURIComponent(id)}`, { method: 'PATCH', body })
+export async function updateUser(
+  id: string,
+  body: UpdateUserDto
+): Promise<void> {
+  await requestJson<void>(`/api/user/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    body,
+  });
 }
 
 export async function deleteUser(id: string): Promise<void> {
-  await requestVoid(`/api/user/${encodeURIComponent(id)}`, { method: 'DELETE' })
+  await requestVoid(`/api/user/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
 }


### PR DESCRIPTION
## Summary
- add a reusable `toQueryString` helper that converts filter objects into `URLSearchParams`
- simplify association, user, and task listing services by using the shared helper

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c8910d6280832bbb1a8bbda0ec6f1c