### PR TITLE
Refatora serviço de tarefas

### DIFF
--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,14 +1,31 @@
-import { createClient } from '@/lib/client'
+import type { User } from '@supabase/supabase-js';
+
+import { createClient } from '@/lib/client';
 
 export async function getAccessToken(): Promise<string | null> {
-  const supabase = createClient()
-  const { data } = await supabase.auth.getSession()
-  return data.session?.access_token ?? null
+  const supabase = createClient();
+  const { data } = await supabase.auth.getSession();
+  return data.session?.access_token ?? null;
+}
+
+export async function ensureAuthenticated(user?: User | null): Promise<User> {
+  if (user) return user;
+
+  const supabase = createClient();
+  const {
+    data: { user: currentUser },
+  } = await supabase.auth.getUser();
+
+  if (!currentUser) {
+    throw new Error('Usuário não autenticado');
+  }
+
+  return currentUser;
 }
 
 export async function authHeaders(extra?: HeadersInit): Promise<HeadersInit> {
-  const token = await getAccessToken()
-  const h = new Headers(extra)
-  if (token) h.set('Authorization', `Bearer ${token}`)
-  return h
+  const token = await getAccessToken();
+  const h = new Headers(extra);
+  if (token) h.set('Authorization', `Bearer ${token}`);
+  return h;
 }

--- a/src/services/tarefas/index.ts
+++ b/src/services/tarefas/index.ts
@@ -1,2 +1,3 @@
-export * from "./update-task";
-export * from "./delete-task";
+export * from './update-task';
+export * from './delete-task';
+export * from './task-service';

--- a/src/services/tarefas/task-service.ts
+++ b/src/services/tarefas/task-service.ts
@@ -1,0 +1,12 @@
+import type { HttpClient } from '@/services/http-client';
+
+export class TaskService {
+  constructor(private readonly httpClient: HttpClient) {}
+
+  async updateTask(id: string, body: Record<string, unknown>): Promise<void> {
+    await this.httpClient.requestVoid(`/api/task/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      body,
+    });
+  }
+}

--- a/src/services/tarefas/update-task.ts
+++ b/src/services/tarefas/update-task.ts
@@ -1,5 +1,11 @@
-import { createClient } from "@/lib/client";
-import { requestVoid } from "@/services/http";
+import type { User } from '@supabase/supabase-js';
+
+import { ensureAuthenticated } from '@/lib/auth-client';
+import { httpClient } from '@/services/http';
+
+import { TaskService } from './task-service';
+
+const taskService = new TaskService(httpClient);
 
 export interface UpdateTaskInput {
   id: string;
@@ -13,25 +19,29 @@ export interface UpdateTaskInput {
   data_fim?: Date;
 }
 
-export async function updateTask(input: UpdateTaskInput): Promise<void> {
-  const supabase = createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+export async function updateTask(
+  input: UpdateTaskInput,
+  user?: User | null
+): Promise<void> {
+  await ensureAuthenticated(user);
 
-  if (!user) {
-    throw new Error("Usuário não autenticado");
-  }
+  const body = buildUpdatePayload(input);
+  await taskService.updateTask(input.id, body);
+}
 
+function buildUpdatePayload(input: UpdateTaskInput): Record<string, unknown> {
   const body: Record<string, unknown> = {};
   if (input.titulo !== undefined) body.title = input.titulo;
   if (input.descricao !== undefined) body.description = input.descricao;
   if (input.prioridade !== undefined) body.priority = input.prioridade;
-  if (input.data_fim !== undefined) body.dueDate = input.data_fim ? new Date(input.data_fim).toISOString() : null;
+  if (input.data_fim !== undefined)
+    body.dueDate = input.data_fim
+      ? new Date(input.data_fim).toISOString()
+      : null;
   if (input.teamIds) body.teamIds = input.teamIds;
   else if (input.responsavelId) body.teamIds = [input.responsavelId];
   if (input.associacaoId) body.associationId = input.associacaoId;
   if (input.status) body.status = input.status; // expecting values: open|inProgress|finished|canceled
 
-  await requestVoid(`/api/task/${encodeURIComponent(input.id)}`, { method: "PATCH", body });
+  return body;
 }


### PR DESCRIPTION
## Summary
- adiciona utilitário `ensureAuthenticated` para validar usuário autenticado
- cria `TaskService` baseado em `HttpClient` e refatora `updateTask` para usá-lo
- extrai construção do payload de atualização e mantém exportações consolidadas

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c893bf3c60832bb169ff8b5d16060b