### PR TITLE
refactor: extract typed hooks for task options

### DIFF
--- a/src/hooks/use-task-options.ts
+++ b/src/hooks/use-task-options.ts
@@ -1,12 +1,19 @@
-import { useEffect, useState } from "react";
-import { requestJson } from "@/services/http";
+import { useEffect, useMemo, useState } from 'react';
+
+import { statuses } from '@/lib/enums';
+import { requestJson } from '@/services/http';
+import type { AssociationsResponse, UsersResponse } from '@/types/api';
 
 export interface SelectOption {
   value: string;
   label: string;
 }
 
-// Tipos de apoio não são necessários; respostas são tratadas genericamente
+interface SelectOptionsState {
+  options: SelectOption[];
+  loading: boolean;
+  error: string | null;
+}
 
 interface TaskOptions {
   usuarios: SelectOption[];
@@ -17,68 +24,149 @@ interface TaskOptions {
   error: string | null;
 }
 
-async function fetchJson<T>(path: string): Promise<T> {
-  return requestJson<T>(path);
+const USERS_ENDPOINT = '/api/user?limit=100&page=1';
+const ASSOCIATIONS_ENDPOINT = '/api/association?limit=100&page=1';
+const LOAD_OPTIONS_ERROR = 'Erro ao carregar opções';
+
+type UserListItem = UsersResponse['items'][number];
+type AssociationListItem = AssociationsResponse['items'][number];
+
+function logDebugError(message: string, error: unknown) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(message, error);
+  }
 }
 
-export function useTaskOptions(enabled: boolean): TaskOptions {
-  const [usuarios, setUsuarios] = useState<SelectOption[]>([]);
-  const [associacoes, setAssociacoes] = useState<SelectOption[]>([]);
-  const [tipos, setTipos] = useState<SelectOption[]>([]);
+function toUserOption(user: UserListItem): SelectOption {
+  const displayName =
+    user.name && user.name.trim().length > 0 ? user.name : user.email;
+  const roleLabel = user.role.toLowerCase();
+  return {
+    value: user.id,
+    label: `${displayName} - ${roleLabel}`,
+  };
+}
+
+function toAssociationOption(association: AssociationListItem): SelectOption {
+  const label =
+    association.name && association.name.trim().length > 0
+      ? association.name
+      : association.cnpj;
+  return {
+    value: association.id,
+    label,
+  };
+}
+
+export function useUsersOptions(enabled: boolean): SelectOptionsState {
+  const [options, setOptions] = useState<SelectOption[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!enabled) return;
 
-    let ignore = false;
+    let active = true;
 
-    async function fetchOptions() {
+    async function loadUsers() {
       setLoading(true);
       setError(null);
+
       try {
-        const [usersRes, associationsRes] = await Promise.all([
-          fetchJson<{ items?: any[] }>("/api/user?limit=100&page=1"),
-          fetchJson<{ items?: any[] }>("/api/association?limit=100&page=1"),
-        ]);
+        const response = await requestJson<UsersResponse>(USERS_ENDPOINT);
+        if (!active) return;
 
-        if (ignore) return;
+        setOptions(response.items.map(toUserOption));
+      } catch (err: unknown) {
+        if (!active) return;
 
-        const users: any[] = Array.isArray(usersRes?.items) ? usersRes.items : [];
-        const associations: any[] = Array.isArray(associationsRes?.items)
-          ? associationsRes.items
-          : [];
-        setUsuarios(
-          users.map((u: any) => ({
-            value: u.id,
-            label: `${u.name ?? u.email ?? "Usuário"} - ${(u.role ?? "").toString().toLowerCase()}`,
-          })),
-        );
-        setAssociacoes(
-          associations.map((a: any) => ({
-            value: a.id,
-            label: a.name ?? a.nome ?? "Associação",
-          })),
-        );
-        const { statuses } = await import("@/lib/enums");
-        setTipos(statuses.map((s) => ({ value: s.value, label: s.label })));
-      } catch (err) {
-        if (!ignore) {
-          setError("Erro ao carregar opções");
-        }
+        logDebugError('Erro ao carregar usuários', err);
+        setOptions([]);
+        setError(LOAD_OPTIONS_ERROR);
       } finally {
-        if (!ignore) {
+        if (active) {
           setLoading(false);
         }
       }
     }
 
-    fetchOptions();
+    void loadUsers();
 
     return () => {
-      ignore = true;
+      active = false;
     };
   }, [enabled]);
 
-  return { usuarios, associacoes, tipos, loading, error };
+  return { options, loading, error };
+}
+
+export function useAssociationsOptions(enabled: boolean): SelectOptionsState {
+  const [options, setOptions] = useState<SelectOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let active = true;
+
+    async function loadAssociations() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await requestJson<AssociationsResponse>(
+          ASSOCIATIONS_ENDPOINT
+        );
+        if (!active) return;
+
+        setOptions(response.items.map(toAssociationOption));
+      } catch (err: unknown) {
+        if (!active) return;
+
+        logDebugError('Erro ao carregar associações', err);
+        setOptions([]);
+        setError(LOAD_OPTIONS_ERROR);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadAssociations();
+
+    return () => {
+      active = false;
+    };
+  }, [enabled]);
+
+  return { options, loading, error };
+}
+
+export function useTaskOptions(enabled: boolean): TaskOptions {
+  const {
+    options: usuarios,
+    loading: usersLoading,
+    error: usersError,
+  } = useUsersOptions(enabled);
+  const {
+    options: associacoes,
+    loading: associationsLoading,
+    error: associationsError,
+  } = useAssociationsOptions(enabled);
+
+  const tipos = useMemo<SelectOption[]>(
+    () =>
+      statuses.map((status) => ({ value: status.value, label: status.label })),
+    []
+  );
+
+  return {
+    usuarios,
+    associacoes,
+    tipos,
+    loading: usersLoading || associationsLoading,
+    error: usersError ?? associationsError,
+  };
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,49 +1,73 @@
 // Shared API DTOs and helpers
 
-export type UserRole = 'admin' | 'editor'
+export type UserRole = 'admin' | 'editor';
 
 export interface User {
-  id: string
-  name: string
-  email: string
-  role: UserRole
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
 }
 
 export interface Association {
-  id: string
-  name: string
-  cnpj: string
-  status: boolean
+  id: string;
+  name: string;
+  cnpj: string;
+  status: boolean;
 }
 
-export type TaskStatus = 'open' | 'inProgress' | 'finished' | 'canceled'
-export type TaskPriority = 'low' | 'medium' | 'high'
+export type TaskStatus = 'open' | 'inProgress' | 'finished' | 'canceled';
+export type TaskPriority = 'low' | 'medium' | 'high';
 
 // Shape returned by backend for tasks in listings
 export interface TaskApi {
-  id: string
-  createdAt: string
-  title: string
-  description: string
-  status?: TaskStatus | null
-  priority?: TaskPriority | null
-  dueDate?: string | null
-  creator?: { id: string; name?: string; email?: string; role?: UserRole } | null
-  association?: { id: string; name?: string; cnpj?: string; status?: boolean } | null
-  team?: { id: string; name?: string; email?: string; role?: UserRole }[] | null
+  id: string;
+  createdAt: string;
+  title: string;
+  description: string;
+  status?: TaskStatus | null;
+  priority?: TaskPriority | null;
+  dueDate?: string | null;
+  creator?: {
+    id: string;
+    name?: string;
+    email?: string;
+    role?: UserRole;
+  } | null;
+  association?: {
+    id: string;
+    name?: string;
+    cnpj?: string;
+    status?: boolean;
+  } | null;
+  team?:
+    | { id: string; name?: string; email?: string; role?: UserRole }[]
+    | null;
 }
 
 export interface Paginated<T> {
-  items: T[]
-  total: number
-  page: number
-  limit: number
-  pageCount: number
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  pageCount: number;
 }
 
-// Commands
-export interface CreateUserDto { name: string; email: string; role: UserRole }
-export type UpdateUserDto = Partial<CreateUserDto>
+// Specific responses
+export interface UsersResponse extends Paginated<User> {}
+export interface AssociationsResponse extends Paginated<Association> {}
 
-export interface CreateAssociationDto { name: string; cnpj: string; status?: boolean }
-export type UpdateAssociationDto = Partial<CreateAssociationDto>
+// Commands
+export interface CreateUserDto {
+  name: string;
+  email: string;
+  role: UserRole;
+}
+export type UpdateUserDto = Partial<CreateUserDto>;
+
+export interface CreateAssociationDto {
+  name: string;
+  cnpj: string;
+  status?: boolean;
+}
+export type UpdateAssociationDto = Partial<CreateAssociationDto>;


### PR DESCRIPTION
## Summary
- add typed response interfaces for the users and associations endpoints
- expose dedicated hooks to build user and association select options
- refactor the task options hook to reuse the new hooks and remove `any`

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c896a74c54832b96f56dd24a6d49ef