### PR TITLE
Refactor sidebar to consume navigation config

### DIFF
--- a/src/app/(protected)/dashboard/layout.tsx
+++ b/src/app/(protected)/dashboard/layout.tsx
@@ -1,11 +1,12 @@
-import { AppSidebar } from "@/components/AppSidebar"
-import { DynamicBreadcrumb } from "@/components/DynamicBreadcrumb"
-import { Separator } from "@/components/ui/Separator"
+import { AppSidebar } from '@/components/AppSidebar';
+import { navMain, teams, user } from '@/config/navigation';
+import { DynamicBreadcrumb } from '@/components/DynamicBreadcrumb';
+import { Separator } from '@/components/ui/Separator';
 import {
   SidebarInset,
   SidebarProvider,
   SidebarTrigger,
-} from "@/components/ui/Sidebar"
+} from '@/components/ui/Sidebar';
 
 export default function DashboardLayout({
   children,
@@ -14,7 +15,7 @@ export default function DashboardLayout({
 }>) {
   return (
     <SidebarProvider>
-      <AppSidebar />
+      <AppSidebar items={navMain} teams={teams} user={user} />
       <SidebarInset>
         <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
           <div className="flex items-center gap-2 px-4">
@@ -26,10 +27,8 @@ export default function DashboardLayout({
             <DynamicBreadcrumb />
           </div>
         </header>
-        <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-          {children}
-        </div>
+        <div className="flex flex-1 flex-col gap-4 p-4 pt-0">{children}</div>
       </SidebarInset>
     </SidebarProvider>
-  )
+  );
 }

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,96 +1,95 @@
-"use client"
+'use client';
 
-import * as React from "react"
+import * as React from 'react';
 import {
   AudioWaveform,
   Building2,
   Command,
-  Frame,
   GalleryVerticalEnd,
   LayoutDashboard,
   ListTodo,
-  Map,
-  PieChart,
-  Settings2,
   Users2,
-} from "lucide-react"
+  type LucideIcon,
+} from 'lucide-react';
 
-import { NavMain } from "@/components/NavMain"
-import { NavProjects } from "@/components/NavProjects"
-import { NavUser } from "@/components/NavUser"
-import { TeamSwitcher } from "@/components/TeamSwitcher"
+import type {
+  NavigationItem,
+  NavigationTeam,
+  NavigationUser,
+} from '@/config/navigation';
+import { NavMain } from '@/components/NavMain';
+import { NavUser } from '@/components/NavUser';
+import { TeamSwitcher } from '@/components/TeamSwitcher';
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarHeader,
   SidebarRail,
-} from "@/components/ui/Sidebar"
+} from '@/components/ui/Sidebar';
 
-// This is sample data.
-const data = {
-  user: {
-    name: "shadcn",
-    email: "m@example.com",
-    avatar: "/next.svg",
-  },
-  teams: [
-    {
-      name: "Acme Inc",
-      logo: GalleryVerticalEnd,
-      plan: "Enterprise",
-    },
-    {
-      name: "Acme Corp.",
-      logo: AudioWaveform,
-      plan: "Startup",
-    },
-    {
-      name: "Evil Corp.",
-      logo: Command,
-      plan: "Free",
-    },
-  ],
-  navMain: [
-    {
-      title: "Dashboard",
-      url: "/dashboard",
-      icon: LayoutDashboard,
-    },
-    {
-      title: "Associações",
-      url: "/dashboard/associacoes",
-      icon: Building2,
-    },
-    {
-      title: "Tarefas",
-      url: "/dashboard/tarefas",
-      icon: ListTodo,
-    },
-    {
-      title: "Usuários",
-      url: "/dashboard/usuarios",
-      icon: Users2,
-    },
-  ]
-}
+type AppSidebarProps = React.ComponentProps<typeof Sidebar> & {
+  items: NavigationItem[];
+  user: NavigationUser;
+  teams?: NavigationTeam[];
+};
 
-export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+type NavigationIconName = NonNullable<NavigationItem['icon']>;
+
+const navigationIcons: Record<NavigationIconName, LucideIcon> = {
+  LayoutDashboard,
+  Building2,
+  ListTodo,
+  Users2,
+};
+
+const teamLogos: Record<NavigationTeam['logo'], LucideIcon> = {
+  GalleryVerticalEnd,
+  AudioWaveform,
+  Command,
+};
+
+export function AppSidebar({ items, user, teams, ...props }: AppSidebarProps) {
+  const sidebarItems = React.useMemo<
+    React.ComponentProps<typeof NavMain>['items']
+  >(
+    () =>
+      items.map((item) => ({
+        ...item,
+        icon: item.icon ? navigationIcons[item.icon] : undefined,
+      })),
+    [items]
+  );
+
+  const sidebarTeams = React.useMemo<
+    React.ComponentProps<typeof TeamSwitcher>['teams']
+  >(
+    () =>
+      (teams ?? []).map((team) => ({
+        ...team,
+        logo: teamLogos[team.logo],
+      })),
+    [teams]
+  );
+
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
-        <div className="flex items-center gap-2">
-
-          <h1 className="text-lg font-semibold">Econtese</h1>
-        </div>
+        {sidebarTeams.length > 0 ? (
+          <TeamSwitcher teams={sidebarTeams} />
+        ) : (
+          <div className="flex items-center gap-2">
+            <h1 className="text-lg font-semibold">Econtese</h1>
+          </div>
+        )}
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={data.navMain} />
+        <NavMain items={sidebarItems} />
       </SidebarContent>
       <SidebarFooter>
-        <NavUser user={data.user} />
+        <NavUser user={user} />
       </SidebarFooter>
       <SidebarRail />
     </Sidebar>
-  )
+  );
 }

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -1,0 +1,77 @@
+export type NavigationIcon =
+  | 'LayoutDashboard'
+  | 'Building2'
+  | 'ListTodo'
+  | 'Users2';
+
+export type NavigationTeamLogo =
+  | 'GalleryVerticalEnd'
+  | 'AudioWaveform'
+  | 'Command';
+
+export type NavigationItem = {
+  title: string;
+  url: string;
+  icon?: NavigationIcon;
+  isActive?: boolean;
+  items?: { title: string; url: string }[];
+};
+
+export type NavigationTeam = {
+  name: string;
+  logo: NavigationTeamLogo;
+  plan: string;
+};
+
+export type NavigationUser = {
+  name: string;
+  email: string;
+  avatar: string;
+};
+
+export const user = {
+  name: 'shadcn',
+  email: 'm@example.com',
+  avatar: '/next.svg',
+} satisfies NavigationUser;
+
+export const teams = [
+  {
+    name: 'Acme Inc',
+    logo: 'GalleryVerticalEnd',
+    plan: 'Enterprise',
+  },
+  {
+    name: 'Acme Corp.',
+    logo: 'AudioWaveform',
+    plan: 'Startup',
+  },
+  {
+    name: 'Evil Corp.',
+    logo: 'Command',
+    plan: 'Free',
+  },
+] satisfies NavigationTeam[];
+
+export const navMain = [
+  {
+    title: 'Dashboard',
+    url: '/dashboard',
+    icon: 'LayoutDashboard',
+  },
+  {
+    title: 'Associações',
+    url: '/dashboard/associacoes',
+    icon: 'Building2',
+  },
+  {
+    title: 'Tarefas',
+    url: '/dashboard/tarefas',
+    icon: 'ListTodo',
+  },
+  {
+    title: 'Usuários',
+    url: '/dashboard/usuarios',
+    icon: 'Users2',
+  },
+] satisfies NavigationItem[];


### PR DESCRIPTION
## Summary
- create a navigation config module that exports the sidebar user, team and nav item data
- update the AppSidebar to receive the navigation data via props and resolve icon keys to lucide components
- import the navigation config in the dashboard layout and pass the items, teams and user to the sidebar

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c899738938832b8c0d27c5ce12de52