### PR TITLE
Add configurable logger for HTTP requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "ESLINT_USE_FLAT_CONFIG=false eslint --fix",
+      "env ESLINT_USE_FLAT_CONFIG=false eslint --fix",
       "prettier --write"
     ],
     "*.{json,css,md}": [

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,113 @@
+export type LogFunction = (
+  message?: unknown,
+  ...optionalParams: unknown[]
+) => void;
+
+export type LogLevel = 'silent' | 'error' | 'warn' | 'info';
+
+export type Logger = {
+  error: LogFunction;
+  warn: LogFunction;
+  info: LogFunction;
+};
+
+const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  silent: -1,
+  error: 0,
+  warn: 1,
+  info: 2,
+} as const;
+
+const resolveEnvLogLevel = (): LogLevel | undefined => {
+  if (typeof process === 'undefined') {
+    return undefined;
+  }
+
+  const rawValue = process.env.NEXT_PUBLIC_LOG_LEVEL ?? process.env.LOG_LEVEL;
+  if (!rawValue) {
+    return undefined;
+  }
+
+  switch (rawValue.trim().toLowerCase()) {
+    case 'silent':
+    case 'none':
+    case 'off':
+      return 'silent';
+    case 'error':
+    case 'err':
+      return 'error';
+    case 'warn':
+    case 'warning':
+      return 'warn';
+    case 'info':
+    case 'information':
+      return 'info';
+    default:
+      return undefined;
+  }
+};
+
+const defaultLogLevel: LogLevel =
+  typeof process !== 'undefined' && process.env.NODE_ENV === 'production'
+    ? 'error'
+    : 'warn';
+
+const currentLogLevel: LogLevel = resolveEnvLogLevel() ?? defaultLogLevel;
+
+const shouldLog = (level: Exclude<LogLevel, 'silent'>): boolean => {
+  return LOG_LEVEL_PRIORITY[level] <= LOG_LEVEL_PRIORITY[currentLogLevel];
+};
+
+const bindConsoleMethod = (method: 'error' | 'warn' | 'info'): LogFunction => {
+  if (typeof console === 'undefined') {
+    return () => {};
+  }
+
+  const consoleMethod = console[method];
+  if (typeof consoleMethod !== 'function') {
+    return () => {};
+  }
+
+  return consoleMethod.bind(console);
+};
+
+const createLogFunction = (
+  level: Exclude<LogLevel, 'silent'>,
+  handler: LogFunction
+): LogFunction => {
+  return (message?: unknown, ...optionalParams: unknown[]) => {
+    if (!shouldLog(level)) {
+      return;
+    }
+    handler(message, ...optionalParams);
+  };
+};
+
+export const error: LogFunction = createLogFunction(
+  'error',
+  bindConsoleMethod('error')
+);
+export const warn: LogFunction = createLogFunction(
+  'warn',
+  bindConsoleMethod('warn')
+);
+export const info: LogFunction = createLogFunction(
+  'info',
+  bindConsoleMethod('info')
+);
+
+const baseLogger: Logger = {
+  error,
+  warn,
+  info,
+};
+
+export const logger: Logger = baseLogger;
+
+Object.freeze(baseLogger);
+
+export const getLogLevel = (): LogLevel => currentLogLevel;
+
+export const isLogLevelEnabled = (
+  level: Exclude<LogLevel, 'silent'>
+): boolean => shouldLog(level);

--- a/src/services/http-client.ts
+++ b/src/services/http-client.ts
@@ -1,139 +1,169 @@
-export type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+import type { Logger } from '@/lib/logger';
+import { logger as defaultLogger } from '@/lib/logger';
+
+export type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 
 export interface RequestOptions {
-  method?: HttpMethod
-  headers?: HeadersInit
-  body?: unknown
+  method?: HttpMethod;
+  headers?: HeadersInit;
+  body?: unknown;
 }
 
-type TokenProvider = () => string | null | undefined | Promise<string | null | undefined>
-type UrlResolver = (path: string) => string
+type TokenProvider = () =>
+  | string
+  | null
+  | undefined
+  | Promise<string | null | undefined>;
+type UrlResolver = (path: string) => string;
 
 interface HttpClientConfig {
-  getToken?: TokenProvider
-  resolveUrl: UrlResolver
-  loggerLabel?: string
+  getToken?: TokenProvider;
+  resolveUrl: UrlResolver;
+  loggerLabel?: string;
+  logger?: Logger;
 }
 
 export class HttpClient {
-  private readonly tokenProvider?: TokenProvider
-  private readonly resolveUrl: UrlResolver
-  private readonly loggerLabel: string
+  private readonly tokenProvider?: TokenProvider;
+  private readonly resolveUrl: UrlResolver;
+  private readonly loggerLabel: string;
+  private readonly logger: Logger;
 
-  constructor({ getToken, resolveUrl, loggerLabel }: HttpClientConfig) {
-    this.tokenProvider = getToken
-    this.resolveUrl = resolveUrl
-    this.loggerLabel = loggerLabel ?? 'HTTP'
+  constructor({ getToken, resolveUrl, loggerLabel, logger }: HttpClientConfig) {
+    this.tokenProvider = getToken;
+    this.resolveUrl = resolveUrl;
+    this.loggerLabel = loggerLabel ?? 'HTTP';
+    this.logger = logger ?? defaultLogger;
   }
 
-  requestJson = async <T>(path: string, opts: RequestOptions = {}): Promise<T> => {
-    const method = opts.method ?? 'GET'
-    const url = this.resolveUrl(path)
-    const headers = await this.createBaseHeaders()
-    headers.set('Content-Type', 'application/json')
-    this.mergeHeaders(headers, opts.headers)
+  requestJson = async <T>(
+    path: string,
+    opts: RequestOptions = {}
+  ): Promise<T> => {
+    const method = opts.method ?? 'GET';
+    const url = this.resolveUrl(path);
+    const headers = await this.createBaseHeaders();
+    headers.set('Content-Type', 'application/json');
+    this.mergeHeaders(headers, opts.headers);
 
     const res = await fetch(url, {
       method,
       headers,
       body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
       cache: 'no-store',
-    })
+    });
 
-    const ct = res.headers.get('content-type') || ''
-    const raw = await res.text()
-    const maybeJson = ct.includes('application/json')
-    let parsed: unknown = undefined
+    const ct = res.headers.get('content-type') || '';
+    const raw = await res.text();
+    const maybeJson = ct.includes('application/json');
+    let parsed: unknown = undefined;
     if (maybeJson) {
       try {
-        parsed = JSON.parse(raw)
+        parsed = JSON.parse(raw);
       } catch {}
     }
 
     if (!res.ok) {
-      const message = this.extractApiMessage(parsed, raw)
-      this.log(`[${this.loggerLabel} ${method}] ${path} -> ${res.status}: ${message}`)
-      throw new Error(message)
+      const message = this.extractApiMessage(parsed, raw);
+      this.log(
+        `[${this.loggerLabel} ${method}] ${path} -> ${res.status}: ${message}`
+      );
+      throw new Error(message);
     }
 
     if (!maybeJson) {
-      this.log(`[${this.loggerLabel}] ${path} -> Non-JSON content-type: ${ct}; preview:`, raw.slice(0, 200))
-      throw new Error('Non-JSON response')
+      this.log(
+        `[${this.loggerLabel}] ${path} -> Non-JSON content-type: ${ct}; preview:`,
+        raw.slice(0, 200)
+      );
+      throw new Error('Non-JSON response');
     }
 
     if (parsed === undefined) {
-      this.log(`[${this.loggerLabel}] ${path} -> Invalid JSON; preview:`, raw.slice(0, 200))
-      throw new Error('Invalid JSON response')
+      this.log(
+        `[${this.loggerLabel}] ${path} -> Invalid JSON; preview:`,
+        raw.slice(0, 200)
+      );
+      throw new Error('Invalid JSON response');
     }
 
-    return parsed as T
-  }
+    return parsed as T;
+  };
 
-  requestVoid = async (path: string, opts: RequestOptions = {}): Promise<void> => {
-    const method = opts.method ?? 'DELETE'
-    const url = this.resolveUrl(path)
-    const headers = await this.createBaseHeaders()
-    this.mergeHeaders(headers, opts.headers)
+  requestVoid = async (
+    path: string,
+    opts: RequestOptions = {}
+  ): Promise<void> => {
+    const method = opts.method ?? 'DELETE';
+    const url = this.resolveUrl(path);
+    const headers = await this.createBaseHeaders();
+    this.mergeHeaders(headers, opts.headers);
 
     const res = await fetch(url, {
       method,
       headers,
       body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
       cache: 'no-store',
-    })
+    });
 
     if (!res.ok) {
-      const ct = res.headers.get('content-type') || ''
-      const raw = await res.text()
-      let parsed: unknown = undefined
+      const ct = res.headers.get('content-type') || '';
+      const raw = await res.text();
+      let parsed: unknown = undefined;
       if (ct.includes('application/json')) {
         try {
-          parsed = JSON.parse(raw)
+          parsed = JSON.parse(raw);
         } catch {}
       }
 
-      const message = this.extractApiMessage(parsed, raw)
-      this.log(`[${this.loggerLabel} ${method}] ${path} -> ${res.status}: ${message}`)
-      throw new Error(message)
+      const message = this.extractApiMessage(parsed, raw);
+      this.log(
+        `[${this.loggerLabel} ${method}] ${path} -> ${res.status}: ${message}`
+      );
+      throw new Error(message);
     }
-  }
+  };
 
   private async createBaseHeaders(): Promise<Headers> {
-    const headers = new Headers({ Accept: 'application/json' })
-    const token = this.tokenProvider ? await this.tokenProvider() : undefined
+    const headers = new Headers({ Accept: 'application/json' });
+    const token = this.tokenProvider ? await this.tokenProvider() : undefined;
     if (token) {
-      headers.set('Authorization', `Bearer ${token}`)
+      headers.set('Authorization', `Bearer ${token}`);
     }
-    return headers
+    return headers;
   }
 
   private mergeHeaders(base: Headers, extra?: HeadersInit): Headers {
-    if (!extra) return base
+    if (!extra) return base;
     if (extra instanceof Headers) {
-      extra.forEach((v, k) => base.set(k, v))
+      extra.forEach((v, k) => base.set(k, v));
     } else if (Array.isArray(extra)) {
-      extra.forEach(([k, v]) => base.set(k, v))
+      extra.forEach(([k, v]) => base.set(k, v));
     } else {
-      Object.entries(extra).forEach(([k, v]) => base.set(k, String(v)))
+      Object.entries(extra).forEach(([k, v]) => base.set(k, String(v)));
     }
-    return base
+    return base;
   }
 
   private extractApiMessage(payload: unknown, fallback: string): string {
     if (payload && typeof payload === 'object') {
-      if ('message' in payload && typeof (payload as { message?: unknown }).message === 'string') {
-        return (payload as { message?: string }).message as string
+      if (
+        'message' in payload &&
+        typeof (payload as { message?: unknown }).message === 'string'
+      ) {
+        return (payload as { message?: string }).message as string;
       }
-      if ('error' in payload && typeof (payload as { error?: unknown }).error === 'string') {
-        return (payload as { error?: string }).error as string
+      if (
+        'error' in payload &&
+        typeof (payload as { error?: unknown }).error === 'string'
+      ) {
+        return (payload as { error?: string }).error as string;
       }
     }
-    return fallback
+    return fallback;
   }
 
   private log(message?: unknown, ...optionalParams: unknown[]) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(message, ...optionalParams)
-    }
+    this.logger.warn(message, ...optionalParams);
   }
 }

--- a/src/services/http-server.ts
+++ b/src/services/http-server.ts
@@ -1,22 +1,24 @@
-import { apiUrl, API_BASE_URL } from '@/lib/endpoints'
-import { getServerAccessToken } from '@/lib/auth-server'
+import { getServerAccessToken } from '@/lib/auth-server';
+import { apiUrl, API_BASE_URL } from '@/lib/endpoints';
+import { logger } from '@/lib/logger';
 
-import { HttpClient } from './http-client'
+import { HttpClient } from './http-client';
 
-export type { HttpMethod, RequestOptions } from './http-client'
+export type { HttpMethod, RequestOptions } from './http-client';
 
 const resolveServerUrl = (path: string): string => {
   if (path.startsWith('/api/')) {
-    return new URL(path.replace(/^\/api\//, ''), API_BASE_URL).toString()
+    return new URL(path.replace(/^\/api\//, ''), API_BASE_URL).toString();
   }
-  return apiUrl(path)
-}
+  return apiUrl(path);
+};
 
 export const httpServerClient = new HttpClient({
   getToken: getServerAccessToken,
   resolveUrl: resolveServerUrl,
   loggerLabel: 'HTTP(S)',
-})
+  logger,
+});
 
-export const requestJsonServer = httpServerClient.requestJson
-export const requestVoidServer = httpServerClient.requestVoid
+export const requestJsonServer = httpServerClient.requestJson;
+export const requestVoidServer = httpServerClient.requestVoid;

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,14 +1,16 @@
-import { apiUrl } from '@/lib/endpoints'
-import { getAccessToken } from '@/lib/auth-client'
+import { getAccessToken } from '@/lib/auth-client';
+import { apiUrl } from '@/lib/endpoints';
+import { logger } from '@/lib/logger';
 
-import { HttpClient } from './http-client'
+import { HttpClient } from './http-client';
 
-export type { HttpMethod, RequestOptions } from './http-client'
+export type { HttpMethod, RequestOptions } from './http-client';
 
 export const httpClient = new HttpClient({
   getToken: getAccessToken,
   resolveUrl: apiUrl,
-})
+  logger,
+});
 
-export const requestJson = httpClient.requestJson
-export const requestVoid = httpClient.requestVoid
+export const requestJson = httpClient.requestJson;
+export const requestVoid = httpClient.requestVoid;


### PR DESCRIPTION
## Summary
- introduce a shared logger utility with env-configurable levels and warn/info/error helpers
- wire the HTTP client and its wrappers to use the new logger instead of console calls
- update the lint-staged eslint command to run via env for better shell compatibility

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c92b804a04832ba324d569f68f3f48