### PR TITLE
Refactor Supabase token retrieval

### DIFF
--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,11 +1,11 @@
 import type { User } from '@supabase/supabase-js';
 
 import { createClient } from '@/lib/client';
+import { getSupabaseAccessToken } from '@/lib/supabase-token';
 
 export async function getAccessToken(): Promise<string | null> {
   const supabase = createClient();
-  const { data } = await supabase.auth.getSession();
-  return data.session?.access_token ?? null;
+  return getSupabaseAccessToken(supabase);
 }
 
 export async function ensureAuthenticated(user?: User | null): Promise<User> {

--- a/src/lib/auth-server.ts
+++ b/src/lib/auth-server.ts
@@ -1,14 +1,16 @@
-import { createClient } from '@/lib/server'
+import { createClient } from '@/lib/server';
+import { getSupabaseAccessToken } from '@/lib/supabase-token';
 
 export async function getServerAccessToken(): Promise<string | null> {
-  const supabase = await createClient()
-  const { data } = await supabase.auth.getSession()
-  return data.session?.access_token ?? null
+  const supabase = await createClient();
+  return getSupabaseAccessToken(supabase);
 }
 
-export async function authServerHeaders(extra?: HeadersInit): Promise<HeadersInit> {
-  const token = await getServerAccessToken()
-  const h = new Headers(extra)
-  if (token) h.set('Authorization', `Bearer ${token}`)
-  return h
+export async function authServerHeaders(
+  extra?: HeadersInit
+): Promise<HeadersInit> {
+  const token = await getServerAccessToken();
+  const h = new Headers(extra);
+  if (token) h.set('Authorization', `Bearer ${token}`);
+  return h;
 }

--- a/src/lib/supabase-token.ts
+++ b/src/lib/supabase-token.ts
@@ -1,0 +1,11 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export async function getSupabaseAccessToken(
+  supabase: SupabaseClient
+): Promise<string | null> {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  return session?.access_token ?? null;
+}

--- a/src/services/http-client.ts
+++ b/src/services/http-client.ts
@@ -127,7 +127,6 @@ export class HttpClient {
   private async createBaseHeaders(): Promise<Headers> {
     const headers = new Headers({ Accept: 'application/json' });
     const token = this.tokenProvider ? await this.tokenProvider() : undefined;
-    console.log('token', token);
 
     if (token) {
       headers.set('Authorization', `Bearer ${token}`);


### PR DESCRIPTION
## Summary
- add a shared helper to load the Supabase session access token via auth.getSession
- update client and server token helpers to use the shared accessor instead of inlining logic
- stop logging bearer tokens inside the HTTP client

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c958d375d0832ba573d599eecb3b5f